### PR TITLE
Hold per-context credentials in config; bind token_type to them

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,33 @@ management tool.
     By default, the secrets engine will mount at the name of the engine. To
     enable the secrets engine at a different path, use the `-path` argument.
 
-1. Configure the backend with user credentials that will be able to interact with the cloudflare API and create tokens.
+1. Configure the backend with the parent credentials used to mint and revoke tokens.
+
+    The config holds a credential per **token context** — provide account
+    credentials, user credentials, or both. A role's `token_type` then selects
+    which one is used, and generation fails if the matching context is not
+    configured.
 
     ```text
-    $ vault write cloudflare/config cloudflare_account_id="<account-id>" cloudflare_api_token="<parent-api-token>"
-    Success! Data written to: cloudflare/config
+    # account context (token_type=account)
+    $ vault write cloudflare/config \
+        cloudflare_account_id="<account-id>" \
+        cloudflare_api_token="<account-parent-token>"
+
+    # user context (token_type=user) — can be set instead of, or alongside, the above
+    $ vault write cloudflare/config \
+        cloudflare_user_api_token="<user-parent-token>"
     ```
 
-    `cloudflare_api_token` is a parent Cloudflare API token that is allowed to
-    mint and revoke account-owned tokens (it needs the **API Tokens Write**
-    permission). It is stored seal-wrapped and never returned in plaintext.
-    Optional `ttl` and `max_ttl` fields control the lease duration of generated
-    tokens (defaults: `1h` / `24h`).
+    | Field | Context | Cloudflare permission the parent token needs |
+    | --- | --- | --- |
+    | `cloudflare_account_id` + `cloudflare_api_token` | account | Account · API Tokens · Edit |
+    | `cloudflare_user_api_token` | user | User · API Tokens · Edit |
+
+    At least one context must be configured (`cloudflare_account_id` and
+    `cloudflare_api_token` must be set together). Tokens are stored seal-wrapped
+    and never returned in plaintext. Optional `ttl` and `max_ttl` fields control
+    the lease duration of generated tokens (defaults: `1h` / `24h`).
 
 ### Roles
 
@@ -46,7 +61,9 @@ Tokens are generated from **roles**. A role defines two things:
 - **`token_type`** — the Cloudflare token context: `account` (default; service-tied,
   survives an employee leaving) or `user` (tied to the individual that owns the
   parent API token). Some permission groups and operations are only available in
-  one context or the other.
+  one context or the other. The matching credential must be configured (see
+  Setup) — a `token_type=user` role fails unless `cloudflare_user_api_token` is
+  set, and likewise for the account context.
 - **`policies`** — a JSON array that maps 1:1 to Cloudflare's token policy model.
   Each policy has an `effect` (`allow`/`deny`, default `allow`), a list of
   `permission_groups`, and a `resources` map. This is where the token's ACL and

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -72,12 +72,18 @@ func runLifecycle(t *testing.T, accountID, parentToken, tokenType, policies stri
 	}
 
 	// 1. Configure the backend with the parent credential for this context.
-	mustWrite(t, ctx, b, storage, "config", map[string]interface{}{
-		"cloudflare_account_id": accountID,
-		"cloudflare_api_token":  parentToken,
-		"ttl":                   "5m",
-		"max_ttl":               "10m",
-	})
+	configData := map[string]interface{}{
+		"ttl":     "5m",
+		"max_ttl": "10m",
+	}
+	switch tokenType {
+	case tokenTypeUser:
+		configData["cloudflare_user_api_token"] = parentToken
+	default:
+		configData["cloudflare_account_id"] = accountID
+		configData["cloudflare_api_token"] = parentToken
+	}
+	mustWrite(t, ctx, b, storage, "config", configData)
 
 	// 2. Create a role bound to this token context.
 	mustWrite(t, ctx, b, storage, "role/acc-test", map[string]interface{}{

--- a/backend.go
+++ b/backend.go
@@ -3,7 +3,6 @@ package cloudflaresecrets
 import (
 	"context"
 	"strings"
-	"sync"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -23,9 +22,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 // API tokens.
 type cloudflareBackend struct {
 	*framework.Backend
-
-	lock   sync.RWMutex
-	client *cloudflareClient
 }
 
 func newBackend() *cloudflareBackend {
@@ -47,47 +43,15 @@ func newBackend() *cloudflareBackend {
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{configStoragePath},
 		},
-		Invalidate: b.invalidate,
 	}
 
 	return b
 }
 
-// reset drops the cached client so the next request rebuilds it from the
-// current configuration.
-func (b *cloudflareBackend) reset() {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-	b.client = nil
-}
-
-// invalidate clears the cached client whenever the config changes on another
-// node in an HA cluster.
-func (b *cloudflareBackend) invalidate(ctx context.Context, key string) {
-	if key == configStoragePath {
-		b.reset()
-	}
-}
-
-// getClient returns a cached Cloudflare client, building one from stored
-// configuration on first use.
-func (b *cloudflareBackend) getClient(ctx context.Context, s logical.Storage) (*cloudflareClient, error) {
-	b.lock.RLock()
-	if b.client != nil {
-		client := b.client
-		b.lock.RUnlock()
-		return client, nil
-	}
-	b.lock.RUnlock()
-
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	// Re-check after acquiring the write lock.
-	if b.client != nil {
-		return b.client, nil
-	}
-
+// clientForTokenType loads the config and builds a Cloudflare client using the
+// parent credential for the requested token context (account or user). It fails
+// with a clear error when that context's credentials are not configured.
+func (b *cloudflareBackend) clientForTokenType(ctx context.Context, s logical.Storage, tokenType string) (*cloudflareClient, error) {
 	config, err := getConfig(ctx, s)
 	if err != nil {
 		return nil, err
@@ -96,8 +60,11 @@ func (b *cloudflareBackend) getClient(ctx context.Context, s logical.Storage) (*
 		return nil, errBackendNotConfigured
 	}
 
-	b.client = newCloudflareClient(config.APIToken)
-	return b.client, nil
+	token, err := config.parentTokenFor(tokenType)
+	if err != nil {
+		return nil, err
+	}
+	return newCloudflareClient(token), nil
 }
 
 const backendHelp = `

--- a/path_config.go
+++ b/path_config.go
@@ -23,12 +23,34 @@ const (
 	defaultMax = 24 * time.Hour
 )
 
-// cloudflareConfig is the persisted backend configuration.
+// cloudflareConfig is the persisted backend configuration. It can hold
+// credentials for the account context, the user context, or both; a role's
+// token_type selects which credential is used.
 type cloudflareConfig struct {
-	AccountID string        `json:"cloudflare_account_id"`
-	APIToken  string        `json:"cloudflare_api_token"`
-	TTL       time.Duration `json:"ttl"`
-	MaxTTL    time.Duration `json:"max_ttl"`
+	AccountID    string        `json:"cloudflare_account_id"`
+	APIToken     string        `json:"cloudflare_api_token"`
+	UserAPIToken string        `json:"cloudflare_user_api_token"`
+	TTL          time.Duration `json:"ttl"`
+	MaxTTL       time.Duration `json:"max_ttl"`
+}
+
+// parentTokenFor returns the configured parent API token for a token context,
+// or an error explaining which credential is missing.
+func (c *cloudflareConfig) parentTokenFor(tokenType string) (string, error) {
+	switch tokenType {
+	case tokenTypeUser:
+		if c.UserAPIToken == "" {
+			return "", fmt.Errorf("user credentials are not configured: set cloudflare_user_api_token on the config to use token_type=user roles")
+		}
+		return c.UserAPIToken, nil
+	case tokenTypeAccount, "":
+		if c.APIToken == "" {
+			return "", fmt.Errorf("account credentials are not configured: set cloudflare_account_id and cloudflare_api_token on the config to use token_type=account roles")
+		}
+		return c.APIToken, nil
+	default:
+		return "", fmt.Errorf("invalid token_type %q", tokenType)
+	}
 }
 
 func pathConfig(b *cloudflareBackend) *framework.Path {
@@ -37,18 +59,24 @@ func pathConfig(b *cloudflareBackend) *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"cloudflare_account_id": {
 				Type:        framework.TypeString,
-				Description: "Cloudflare account ID that owns the generated tokens.",
-				Required:    true,
+				Description: "Cloudflare account ID that owns account-context tokens. Required together with cloudflare_api_token.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Cloudflare Account ID",
 				},
 			},
 			"cloudflare_api_token": {
 				Type:        framework.TypeString,
-				Description: "Parent Cloudflare API token used to mint and revoke tokens. Requires the 'API Tokens Write' permission.",
-				Required:    true,
+				Description: "Parent token for the account context (token_type=account). Needs 'Account · API Tokens · Edit'.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name:      "Cloudflare API Token",
+					Sensitive: true,
+				},
+			},
+			"cloudflare_user_api_token": {
+				Type:        framework.TypeString,
+				Description: "Parent token for the user context (token_type=user). Needs 'User · API Tokens · Edit'.",
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:      "Cloudflare User API Token",
 					Sensitive: true,
 				},
 			},
@@ -92,10 +120,11 @@ func (b *cloudflareBackend) pathConfigRead(ctx context.Context, req *logical.Req
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"cloudflare_account_id": config.AccountID,
-			"cloudflare_api_token":  maskToken(config.APIToken),
-			"ttl":                   int64(config.TTL.Seconds()),
-			"max_ttl":               int64(config.MaxTTL.Seconds()),
+			"cloudflare_account_id":     config.AccountID,
+			"cloudflare_api_token":      maskToken(config.APIToken),
+			"cloudflare_user_api_token": maskToken(config.UserAPIToken),
+			"ttl":                       int64(config.TTL.Seconds()),
+			"max_ttl":                   int64(config.MaxTTL.Seconds()),
 		},
 	}, nil
 }
@@ -116,14 +145,12 @@ func (b *cloudflareBackend) pathConfigWrite(ctx context.Context, req *logical.Re
 
 	if v, ok := d.GetOk("cloudflare_account_id"); ok {
 		config.AccountID = v.(string)
-	} else if createOperation {
-		return logical.ErrorResponse("missing cloudflare_account_id"), nil
 	}
-
 	if v, ok := d.GetOk("cloudflare_api_token"); ok {
 		config.APIToken = v.(string)
-	} else if createOperation {
-		return logical.ErrorResponse("missing cloudflare_api_token"), nil
+	}
+	if v, ok := d.GetOk("cloudflare_user_api_token"); ok {
+		config.UserAPIToken = v.(string)
 	}
 
 	if v, ok := d.GetOk("ttl"); ok {
@@ -131,15 +158,24 @@ func (b *cloudflareBackend) pathConfigWrite(ctx context.Context, req *logical.Re
 	} else if createOperation {
 		config.TTL = defaultTTL
 	}
-
 	if v, ok := d.GetOk("max_ttl"); ok {
 		config.MaxTTL = time.Duration(v.(int)) * time.Second
 	} else if createOperation {
 		config.MaxTTL = defaultMax
 	}
-
 	if config.MaxTTL > 0 && config.TTL > config.MaxTTL {
 		return logical.ErrorResponse("ttl cannot exceed max_ttl"), nil
+	}
+
+	// The account context needs both the account ID and its token.
+	if (config.AccountID == "") != (config.APIToken == "") {
+		return logical.ErrorResponse("account credentials require both cloudflare_account_id and cloudflare_api_token"), nil
+	}
+	// At least one usable context (account and/or user) must be configured.
+	hasAccount := config.AccountID != "" && config.APIToken != ""
+	hasUser := config.UserAPIToken != ""
+	if !hasAccount && !hasUser {
+		return logical.ErrorResponse("configure account credentials (cloudflare_account_id + cloudflare_api_token) and/or a user credential (cloudflare_user_api_token)"), nil
 	}
 
 	entry, err := logical.StorageEntryJSON(configStoragePath, config)
@@ -150,18 +186,11 @@ func (b *cloudflareBackend) pathConfigWrite(ctx context.Context, req *logical.Re
 		return nil, err
 	}
 
-	// Drop the cached client so subsequent calls pick up the new credentials.
-	b.reset()
-
 	return nil, nil
 }
 
 func (b *cloudflareBackend) pathConfigDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	err := req.Storage.Delete(ctx, configStoragePath)
-	if err == nil {
-		b.reset()
-	}
-	return nil, err
+	return nil, req.Storage.Delete(ctx, configStoragePath)
 }
 
 func getConfig(ctx context.Context, s logical.Storage) (*cloudflareConfig, error) {

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -1,0 +1,114 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func TestParentTokenFor(t *testing.T) {
+	cfg := &cloudflareConfig{AccountID: "acct", APIToken: "acct-tok", UserAPIToken: "user-tok"}
+
+	if tok, err := cfg.parentTokenFor(tokenTypeAccount); err != nil || tok != "acct-tok" {
+		t.Fatalf("account: got (%q, %v), want (acct-tok, nil)", tok, err)
+	}
+	if tok, err := cfg.parentTokenFor(""); err != nil || tok != "acct-tok" {
+		t.Fatalf("default: got (%q, %v), want (acct-tok, nil)", tok, err)
+	}
+	if tok, err := cfg.parentTokenFor(tokenTypeUser); err != nil || tok != "user-tok" {
+		t.Fatalf("user: got (%q, %v), want (user-tok, nil)", tok, err)
+	}
+
+	// Missing the matching credential must fail clearly.
+	accountOnly := &cloudflareConfig{AccountID: "acct", APIToken: "acct-tok"}
+	if _, err := accountOnly.parentTokenFor(tokenTypeUser); err == nil {
+		t.Fatal("expected error requesting user token when only account creds configured")
+	}
+	userOnly := &cloudflareConfig{UserAPIToken: "user-tok"}
+	if _, err := userOnly.parentTokenFor(tokenTypeAccount); err == nil {
+		t.Fatal("expected error requesting account token when only user creds configured")
+	}
+}
+
+func TestConfigWriteValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		data    map[string]interface{}
+		wantErr bool
+	}{
+		{"account only", map[string]interface{}{"cloudflare_account_id": "a", "cloudflare_api_token": "t"}, false},
+		{"user only", map[string]interface{}{"cloudflare_user_api_token": "u"}, false},
+		{"both", map[string]interface{}{"cloudflare_account_id": "a", "cloudflare_api_token": "t", "cloudflare_user_api_token": "u"}, false},
+		{"account_id without token", map[string]interface{}{"cloudflare_account_id": "a"}, true},
+		{"token without account_id", map[string]interface{}{"cloudflare_api_token": "t"}, true},
+		{"nothing", map[string]interface{}{}, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := &logical.InmemStorage{}
+			conf := logical.TestBackendConfig()
+			conf.StorageView = storage
+			b, err := Factory(ctx, conf)
+			if err != nil {
+				t.Fatalf("factory: %v", err)
+			}
+
+			resp, err := b.HandleRequest(ctx, &logical.Request{
+				Operation: logical.CreateOperation,
+				Path:      "config",
+				Storage:   storage,
+				Data:      c.data,
+			})
+			if err != nil {
+				t.Fatalf("unexpected hard error: %v", err)
+			}
+			gotErr := resp != nil && resp.IsError()
+			if gotErr != c.wantErr {
+				t.Fatalf("wantErr=%v gotErr=%v (resp=%v)", c.wantErr, gotErr, resp)
+			}
+		})
+	}
+}
+
+func TestConfigReadMasksBothTokens(t *testing.T) {
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b, _ := Factory(ctx, conf)
+
+	if _, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "config",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"cloudflare_account_id":     "acct",
+			"cloudflare_api_token":      "secret-account-token",
+			"cloudflare_user_api_token": "secret-user-token",
+		},
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, field := range []string{"cloudflare_api_token", "cloudflare_user_api_token"} {
+		v, _ := resp.Data[field].(string)
+		if strings.Contains(v, "secret-") {
+			t.Fatalf("%s leaked unmasked: %q", field, v)
+		}
+		if !strings.HasPrefix(v, "x") {
+			t.Fatalf("%s not masked: %q", field, v)
+		}
+	}
+}

--- a/path_creds.go
+++ b/path_creds.go
@@ -76,10 +76,13 @@ func (b *cloudflareBackend) pathCredsRead(ctx context.Context, req *logical.Requ
 		ttl = maxTTL
 	}
 
-	client, err := b.getClient(ctx, req.Storage)
+	// Select the parent credential for this role's token context; fail clearly
+	// if that context is not configured.
+	parentToken, err := config.parentTokenFor(scope.Type)
 	if err != nil {
-		return nil, err
+		return logical.ErrorResponse(err.Error()), nil
 	}
+	client := newCloudflareClient(parentToken)
 
 	// Parse the role's stored policies and resolve permission group names → IDs.
 	// The live permission group catalog is only fetched when a policy actually

--- a/secret_token.go
+++ b/secret_token.go
@@ -47,7 +47,7 @@ func (b *cloudflareBackend) secretTokenRevoke(ctx context.Context, req *logical.
 		scope.AccountID = v
 	}
 
-	client, err := b.getClient(ctx, req.Storage)
+	client, err := b.clientForTokenType(ctx, req.Storage, scope.Type)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Previously `cloudflare/config` held a single `cloudflare_api_token` used for both account-owned and user-owned token minting. That's incorrect: the two contexts require **different parent credentials** with different permissions (`Account · API Tokens · Edit` vs `User · API Tokens · Edit`) — as the two CI secrets already demonstrate.

This change makes the config carry a credential **per token context**, and binds a role's `token_type` to the matching one:

| Config fields | Context | Parent token permission |
| --- | --- | --- |
| `cloudflare_account_id` + `cloudflare_api_token` | `token_type=account` | Account · API Tokens · Edit |
| `cloudflare_user_api_token` | `token_type=user` | User · API Tokens · Edit |

You can configure **account, user, or both**. A `token_type=user` role fails with a clear error unless `cloudflare_user_api_token` is set, and likewise for the account context.

## Behavior

- **Config write validation**: `cloudflare_account_id` and `cloudflare_api_token` must be set together; at least one context (account and/or user) must be present.
- **Generation / revocation** pick the parent credential by the role's `token_type` and fail clearly when it's missing.
- The single cached client (which could only hold one token) is replaced by per-context client construction (`clientForTokenType`), removing stale-client risk and the lock/reset/invalidate machinery.
- Config read masks **both** tokens.

## Tests

- Unit: `parentTokenFor`, config-write validation (account-only / user-only / both / incomplete / empty), both-token masking.
- Acceptance: each subtest now writes the matching credential field for its context. `go vet`, `gofmt`, `go test ./...` pass; CI will re-run both live contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)