### PR TITLE
ci: automated semver releases of cross-compiled binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+# On every push to main, derive the next semver from Conventional Commits since
+# the last tag. If a releasable change exists (feat/fix/breaking), tag it and
+# publish binaries with GoReleaser. Docs/chore/ci-only pushes produce no release.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags for version computation
+
+      - name: Compute next version (Conventional Commits)
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          default_bump: false # no bump unless feat/fix/breaking commits exist
+
+      - name: Set up Go
+        if: steps.tag.outputs.new_tag != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Run GoReleaser
+        if: steps.tag.outputs.new_tag != ''
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The tag was just created on HEAD; point GoReleaser at it explicitly.
+          GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.new_tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Go build/test artifacts
 *.test
 *.out
+
+# GoReleaser build output
+/dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,75 @@
+# GoReleaser configuration. Produces the bare plugin binary for the common
+# Vault server / developer architectures plus a checksums.txt whose SHA-256 is
+# exactly what `vault write sys/plugins/catalog ... sha_256=` expects.
+# Docs: https://goreleaser.com
+version: 2
+
+project_name: vault-cloudflare-secret-engine
+
+builds:
+  - id: plugin
+    main: ./cmd/vault-cloudflare-secret-engine
+    binary: vault-cloudflare-secret-engine
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+# Ship the raw binaries (no tarball) so operators can hash and register them
+# directly. One asset per OS/arch.
+archives:
+  - id: binaries
+    formats:
+      - binary
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - "^style:"
+      - "^refactor:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: kalw
+    name: vault-cloudflare-secret-engine
+  prerelease: auto
+  draft: false
+  header: |
+    Pre-built `vault-cloudflare-secret-engine` plugin binaries.
+
+    Download the asset matching your Vault server's OS/arch, verify it against
+    `checksums.txt`, then register the SHA-256 with Vault's plugin catalog. See
+    the README "Install (pre-built binary)" section for the exact steps.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,8 @@ builds:
     goos:
       - linux
       - darwin
+      - freebsd
+      - openbsd
     goarch:
       - amd64
       - arm64

--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 This plugin will allow you to create a secret backend that will use the cloudflare API to generate dynamic short lived cloudflare token.  Usage can be restricted using the highly customizable Vault ACL system.
 
+## Install (pre-built binary)
+
+Each release publishes the bare plugin binary for the common Vault server and
+developer architectures (`linux`/`darwin`, `amd64`/`arm64`) plus a
+`checksums.txt`.
+
+1. Download the asset matching your Vault server from the
+   [latest release](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest),
+   e.g. `vault-cloudflare-secret-engine_<version>_linux_amd64`, together with
+   `checksums.txt`.
+
+2. Verify and install it into Vault's `plugin_directory` under the plugin's
+   command name:
+
+   ```bash
+   sha256sum --ignore-missing -c checksums.txt
+   install -m 0755 vault-cloudflare-secret-engine_<version>_linux_amd64 \
+     /etc/vault/plugins/vault-cloudflare-secret-engine
+   ```
+
+3. Register it with the catalog using the SHA-256 from `checksums.txt`
+   (Vault hashes the file at `plugin_directory/<command>`):
+
+   ```bash
+   SHASUM=$(sha256sum /etc/vault/plugins/vault-cloudflare-secret-engine | cut -d ' ' -f1)
+   vault write sys/plugins/catalog/vault-cloudflare-secret-engine \
+     sha_256="$SHASUM" command="vault-cloudflare-secret-engine"
+   vault secrets enable -path="cloudflare" -plugin-name="vault-cloudflare-secret-engine" plugin
+   ```
+
+Check a binary's build metadata at any time with
+`vault-cloudflare-secret-engine --version`.
+
 ### Setup
 
 Most secrets engines must be configured in advance before they can perform their
@@ -205,3 +238,22 @@ go test -run TestAcceptance -v
 The `user` subtest is skipped unless `CLOUDFLARE_USER_API_TOKEN` is set. Both
 cases default to the same account-scoped policy, since account-scoped permission
 groups are valid in user-owned tokens.
+
+### Releases
+
+Releases are automated. Every push to `main` is analyzed with
+[Conventional Commits](https://www.conventionalcommits.org/): the next
+[semver](https://semver.org/) is derived from the commit types since the last
+tag, the tag is created, and [GoReleaser](https://goreleaser.com) publishes the
+cross-compiled binaries and `checksums.txt` to a GitHub Release.
+
+| Commit prefix | Version bump |
+| --- | --- |
+| `fix:` | patch (`x.y.Z`) |
+| `feat:` | minor (`x.Y.0`) |
+| `feat!:` / `fix!:` / `BREAKING CHANGE:` footer | major (`X.0.0`) |
+| `docs:`, `chore:`, `ci:`, `refactor:`, `test:`, `style:` | no release |
+
+To seed the first release at a specific version, push a tag manually once (e.g.
+`git tag v1.0.0 && git push origin v1.0.0`); subsequent bumps follow from commit
+messages.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This plugin will allow you to create a secret backend that will use the cloudfla
 ## Install (pre-built binary)
 
 Each release publishes the bare plugin binary for the common Vault server and
-developer architectures (`linux`/`darwin`, `amd64`/`arm64`) plus a
-`checksums.txt`.
+developer architectures (`linux`, `darwin`, `freebsd`, `openbsd` × `amd64`,
+`arm64`) plus a `checksums.txt`.
 
 1. Download the asset matching your Vault server from the
    [latest release](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest),

--- a/cmd/vault-cloudflare-secret-engine/main.go
+++ b/cmd/vault-cloudflare-secret-engine/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	cloudflaresecrets "github.com/arcdigital/vault-cloudflare-secret-engine"
@@ -10,7 +11,22 @@ import (
 	"github.com/hashicorp/vault/sdk/plugin"
 )
 
+// Build metadata, injected by GoReleaser via -ldflags at release time.
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+)
+
 func main() {
+	if len(os.Args) == 2 {
+		switch os.Args[1] {
+		case "--version", "-version", "version":
+			fmt.Printf("vault-cloudflare-secret-engine %s (commit %s, built %s)\n", version, commit, date)
+			return
+		}
+	}
+
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
 	if err := flags.Parse(os.Args[1:]); err != nil {


### PR DESCRIPTION
## Summary

Ease deployment for external users by publishing pre-built plugin binaries on every releasable push to `main`, driven by Conventional Commits.

## What's included

**`.goreleaser.yaml`** — builds the bare plugin binary (no archive), `CGO_ENABLED=0`, `-trimpath`, version ldflags, for the standard targets:

| OS | Arch |
| --- | --- |
| linux | amd64, arm64 |
| darwin | amd64, arm64 |
| freebsd | amd64, arm64 |
| openbsd | amd64, arm64 |

Emits one asset per OS/arch (e.g. `vault-cloudflare-secret-engine_<version>_linux_amd64`) plus **`checksums.txt`** — the SHA-256 is exactly what `vault write sys/plugins/catalog … sha_256=` requires.

**`.github/workflows/release.yml`** — on push to `main`:
1. Derive the next semver from Conventional Commits since the last tag (`feat`→minor, `fix`→patch, `feat!`/`BREAKING CHANGE`→major; `docs`/`chore`/`ci`/`refactor`/`test`/`style` → **no release**).
2. Create the tag.
3. Run GoReleaser in the **same job** — so no PAT is needed (avoids the default-token "tag push doesn't trigger workflows" limitation).

**`cmd/main.go`** — `version`/`commit`/`date` injected by GoReleaser, exposed via `--version`.

**README** — new "Install (pre-built binary)" and "Releases" sections.

## Validation

- `goreleaser check` passes.
- `goreleaser build --snapshot` cross-compiles all four targets; the built binary reports injected version metadata via `--version`.
- `go vet`, `gofmt`, `go test ./...` pass.

## First release

To seed at a specific version, push one tag manually (`git tag v1.0.0 && git push origin v1.0.0`); subsequent bumps follow from commit messages. Otherwise the first `feat:` lands `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)