### PR TITLE
ci: build releases on pushed v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,49 +1,69 @@
 name: Release
 
-# On every push to main, derive the next semver from Conventional Commits since
-# the last tag. If a releasable change exists (feat/fix/breaking), tag it and
-# publish binaries with GoReleaser. Docs/chore/ci-only pushes produce no release.
+# Two ways to cut a release:
+#   * push a v* tag          -> build that exact tag (manual / seed releases)
+#   * push to main           -> derive the next semver from Conventional Commits
+#                               since the last tag, create it, and build it
+# Docs/chore/ci-only pushes to main produce no release.
 on:
   push:
     branches: [main]
+    tags: ["v*"]
 
 permissions:
   contents: write
 
 concurrency:
-  group: release
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  release:
+  # Path 1 — a v* tag was pushed directly. Build that tag.
+  tagged:
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # full history + tags for version computation
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Path 2 — push to main. Compute the next version from Conventional Commits,
+  # tag it, and release in the same job (a GITHUB_TOKEN-pushed tag does not
+  # itself trigger the `tagged` job, so there is no double build).
+  auto:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Compute next version (Conventional Commits)
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
-          default_bump: false # no bump unless feat/fix/breaking commits exist
-
-      - name: Set up Go
+          default_bump: false
+      - uses: actions/setup-go@v5
         if: steps.tag.outputs.new_tag != ''
-        uses: actions/setup-go@v5
         with:
           go-version: "1.25"
           cache: true
-
-      - name: Run GoReleaser
+      - uses: goreleaser/goreleaser-action@v6
         if: steps.tag.outputs.new_tag != ''
-        uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The tag was just created on HEAD; point GoReleaser at it explicitly.
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.new_tag }}

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ cross-compiled binaries and `checksums.txt` to a GitHub Release.
 | `feat!:` / `fix!:` / `BREAKING CHANGE:` footer | major (`X.0.0`) |
 | `docs:`, `chore:`, `ci:`, `refactor:`, `test:`, `style:` | no release |
 
-To seed the first release at a specific version, push a tag manually once (e.g.
-`git tag v1.0.0 && git push origin v1.0.0`); subsequent bumps follow from commit
-messages.
+You can also cut a release at any specific version by pushing a `v*` tag
+directly (e.g. `git tag v1.0.0 && git push origin v1.0.0`) — that builds and
+publishes that exact tag. Use this to seed the first release; subsequent bumps
+then follow automatically from commit messages.


### PR DESCRIPTION
## Problem

PR #5's release workflow only ran GoReleaser for tags it created **in-job** (the conventional-commit auto-bump path). A **manually pushed tag** — like a seed `v1.0.0` — has no trigger, so it never produces a release. That's why merging #5 created no release: the merge commits were `ci:`-typed (no bump), and the seed `v1.0.0` tag was never built.

## Fix

Add `on: push: tags: ['v*']` with two jobs:

- **`tagged`** (`github.ref_type == 'tag'`): build the pushed tag with GoReleaser. Covers manual/seed releases.
- **`auto`** (`ref == refs/heads/main`): unchanged — derive next semver from Conventional Commits, tag, and release in the same job.

A `GITHUB_TOKEN`-pushed tag from `auto` does not re-trigger `tagged`, so there's no double build. `concurrency` is keyed per ref.

## After merge

Push a `v*` tag to cut the first real release (the existing `v1.0.0` tag sits on an intermediate commit and has no release — it should be re-cut at `main` HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)