### PR TITLE
ci: link install instructions in release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,5 +73,6 @@ release:
     Pre-built `vault-cloudflare-secret-engine` plugin binaries.
 
     Download the asset matching your Vault server's OS/arch, verify it against
-    `checksums.txt`, then register the SHA-256 with Vault's plugin catalog. See
-    the README "Install (pre-built binary)" section for the exact steps.
+    `checksums.txt`, then register the SHA-256 with Vault's plugin catalog.
+
+    📦 **[Install instructions](https://github.com/kalw/vault-cloudflare-secret-engine#install-pre-built-binary)**


### PR DESCRIPTION
Replaces the plain "see the README" line in the GoReleaser release header with a markdown link to the README's [Install (pre-built binary)](https://github.com/kalw/vault-cloudflare-secret-engine#install-pre-built-binary) section, so every future release's notes point readers straight to the install steps.

The existing `v1.0.0` release notes were already updated in place with the same link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)