### PR TITLE
ci: add badges and per-OS cross-compile matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,28 @@ jobs:
       - name: Unit tests
         run: go test ./... -v
 
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, freebsd, openbsd]
+        goarch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - name: Cross-compile
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: go build -o /dev/null ./cmd/vault-cloudflare-secret-engine
+
   acceptance:
     name: Acceptance tests (live Cloudflare)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # vault-cloudflare-secret-engine
 
+[![CI](https://github.com/kalw/vault-cloudflare-secret-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/kalw/vault-cloudflare-secret-engine/actions/workflows/ci.yml)
+[![Release](https://github.com/kalw/vault-cloudflare-secret-engine/actions/workflows/release.yml/badge.svg)](https://github.com/kalw/vault-cloudflare-secret-engine/actions/workflows/release.yml)
+[![Latest release](https://img.shields.io/github/v/release/kalw/vault-cloudflare-secret-engine?sort=semver&logo=github)](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest)
+[![Go version](https://img.shields.io/github/go-mod/go-version/kalw/vault-cloudflare-secret-engine?logo=go)](go.mod)
+
+**Platforms** — cross-compiled in CI and published each release (`amd64` · `arm64`):
+[![linux](https://img.shields.io/badge/linux-amd64%20%C2%B7%20arm64-FCC624?logo=linux&logoColor=black)](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-amd64%20%C2%B7%20arm64-000000?logo=apple&logoColor=white)](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest)
+[![FreeBSD](https://img.shields.io/badge/FreeBSD-amd64%20%C2%B7%20arm64-AB2B28?logo=freebsd&logoColor=white)](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest)
+[![OpenBSD](https://img.shields.io/badge/OpenBSD-amd64%20%C2%B7%20arm64-F2CA30?logo=openbsd&logoColor=black)](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest)
+
 This plugin will allow you to create a secret backend that will use the cloudflare API to generate dynamic short lived cloudflare token.  Usage can be restricted using the highly customizable Vault ACL system.
 
 ## Install (pre-built binary)


### PR DESCRIPTION
## Summary

Adds README badges and a per-OS build matrix so platform coverage is both visible and verified.

### README badges
- **Status (live):** CI, Release, latest release version, Go version.
- **Platforms:** linux / macOS / FreeBSD / OpenBSD (`amd64` · `arm64`), linking to the latest release's binaries.

### CI build matrix
New `build` job cross-compiles every `GOOS/GOARCH` target (`linux`, `darwin`, `freebsd`, `openbsd` × `amd64`, `arm64`) on each push/PR with `CGO_ENABLED=0`. Each leg shows as its own check (`Build linux/amd64`, …), and the single CI badge now genuinely means "compiles on all supported platforms."

## Note on "per-OS status badges"

GitHub-native status badges are **per-workflow, not per-matrix-leg** — there's no badge endpoint for an individual matrix job. So the per-OS badges here are platform indicators (linking to the release binaries); the *live* verification is the CI matrix, where each OS/arch is its own check. Splitting into one workflow per OS purely to get separate badges would be needless duplication.

## Follow-ups (not in this PR)
- The module path is `github.com/arcdigital/...` while the repo is `kalw/...`; that mismatch breaks `go install` and pkg.go.dev / Go Report Card badges, so those are intentionally omitted. Worth realigning the module path separately.
- No `LICENSE` file yet, so no license badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)