### PR TITLE
feat: hosted policy builder on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Pages
+
+# Publishes the static policy builder in site/ to GitHub Pages.
+# Requires: repo Settings → Pages → Source = "GitHub Actions".
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+      - name: Generate permission group catalog
+        env:
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_USER_TOKEN: ${{ secrets.CLOUDFLARE_USER_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The page falls back to its curated list if this file is absent.
+          if [ -z "${CF_TOKEN:-}" ] || [ -z "${CF_ACCOUNT:-}" ]; then
+            echo "Cloudflare secrets not set; shipping curated catalog only."
+            exit 0
+          fi
+          base="https://api.cloudflare.com/client/v4"
+          acct=$(curl -sf -H "Authorization: Bearer $CF_TOKEN" \
+            "$base/accounts/$CF_ACCOUNT/tokens/permission_groups?per_page=1000" || echo '{"result":[]}')
+          user=$(curl -sf -H "Authorization: Bearer ${CF_USER_TOKEN:-$CF_TOKEN}" \
+            "$base/user/tokens/permission_groups?per_page=1000" || echo '{"result":[]}')
+          jq -n --argjson a "$acct" --argjson u "$user" \
+            '(($a.result // []) + ($u.result // [])) | map({id, name, scopes}) | unique_by(.id)' \
+            > site/permission_groups.json
+          echo "Catalog: $(jq length site/permission_groups.json) permission groups."
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # GoReleaser build output
 /dist/
+
+# Generated at deploy time by the Pages workflow
+site/permission_groups.json

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Permission groups may be referenced by `id` **or** by `name` — names are
 resolved against Cloudflare's live permission-group list when a token is
 generated.
 
+> 🔧 **[Policy builder](https://kalw.github.io/vault-cloudflare-secret-engine/)** —
+> a hosted page that generates the `policies` JSON and the `vault write` command
+> from pick-lists (permission groups, resource scopes). No install required.
+
 ```text
 $ vault write cloudflare/role/dns-editor \
     token_type="account" \

--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ The `resources` map accepts the full Cloudflare resource model, for example:
 List and read roles with `vault list cloudflare/role` and
 `vault read cloudflare/role/dns-editor`.
 
+#### Restricting tokens by client IP
+
+A role may also pin its tokens to client-IP ranges via Cloudflare's
+`condition.request_ip`. Both fields take comma-separated IPv4/IPv6 CIDRs:
+
+```text
+$ vault write cloudflare/role/dns-editor \
+    token_type="account" \
+    policies='[ ... ]' \
+    request_ip_in="203.0.113.0/24,2001:db8::/32" \
+    request_ip_not_in="203.0.113.7/32"
+```
+
+`request_ip_in` is an allow list (the token only works from those addresses);
+`request_ip_not_in` is a deny list. Either or both may be set.
+
 ### Usage
 
 After a role exists, read its credentials endpoint to mint a token:

--- a/acceptance_ip_test.go
+++ b/acceptance_ip_test.go
@@ -1,0 +1,101 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestAcceptance_TokenIPRestriction mints an account-context token from a role
+// carrying request_ip_in/_not_in and confirms Cloudflare persisted the
+// condition.request_ip on the resulting token. Skipped unless VAULT_ACC is set.
+func TestAcceptance_TokenIPRestriction(t *testing.T) {
+	if os.Getenv("VAULT_ACC") == "" {
+		t.Skip("acceptance test; set VAULT_ACC=1 to run")
+	}
+	accountID := requireEnv(t, "CLOUDFLARE_ACCOUNT_ID")
+	apiToken := requireEnv(t, "CLOUDFLARE_API_TOKEN")
+
+	const allowCIDR = "203.0.113.0/24"
+	const denyCIDR = "198.51.100.7/32"
+
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b, err := Factory(ctx, conf)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+
+	mustWrite(t, ctx, b, storage, "config", map[string]interface{}{
+		"cloudflare_account_id": accountID,
+		"cloudflare_api_token":  apiToken,
+		"ttl":                   "5m",
+		"max_ttl":               "10m",
+	})
+	mustWrite(t, ctx, b, storage, "role/ip-test", map[string]interface{}{
+		"token_type": tokenTypeAccount,
+		"policies": fmt.Sprintf(
+			`[{"effect":"allow","permission_groups":[{"name":"Account Settings Read"}],"resources":{"com.cloudflare.api.account.%s":"*"}}]`,
+			accountID),
+		"request_ip_in":     allowCIDR,
+		"request_ip_not_in": denyCIDR,
+	})
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "creds/ip-test",
+		Storage:   storage,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("creds read: err=%v resp=%v", err, resp)
+	}
+	tokenID, _ := resp.Data["token_id"].(string)
+	if tokenID == "" {
+		t.Fatal("no token_id returned")
+	}
+	t.Logf("minted IP-restricted token id=%s", tokenID)
+
+	// Fetch the token from Cloudflare and confirm the condition was stored.
+	client := newCloudflareClient(apiToken)
+	var td struct {
+		Condition *tokenCondition `json:"condition"`
+	}
+	if err := client.do(ctx, http.MethodGet,
+		fmt.Sprintf("/accounts/%s/tokens/%s", accountID, tokenID), nil, &td); err != nil {
+		t.Fatalf("get token details: %v", err)
+	}
+	if td.Condition == nil || td.Condition.RequestIP == nil {
+		t.Fatalf("token has no condition.request_ip: %+v", td.Condition)
+	}
+	if !sliceContains(td.Condition.RequestIP.In, allowCIDR) {
+		t.Fatalf("request_ip.in = %v, want to contain %s", td.Condition.RequestIP.In, allowCIDR)
+	}
+	if !sliceContains(td.Condition.RequestIP.NotIn, denyCIDR) {
+		t.Fatalf("request_ip.not_in = %v, want to contain %s", td.Condition.RequestIP.NotIn, denyCIDR)
+	}
+
+	// Clean up: revoke the lease, which deletes the token.
+	if _, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.RevokeOperation,
+		Path:      "creds/ip-test",
+		Storage:   storage,
+		Secret:    resp.Secret,
+	}); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+}
+
+func sliceContains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/client.go
+++ b/client.go
@@ -88,11 +88,24 @@ type policy struct {
 	PermissionGroups []permissionGroup `json:"permission_groups"`
 }
 
+// requestIP is the client-IP restriction on a token.
+type requestIP struct {
+	In    []string `json:"in,omitempty"`
+	NotIn []string `json:"not_in,omitempty"`
+}
+
+// tokenCondition carries optional token-level conditions (currently only the
+// client-IP restriction).
+type tokenCondition struct {
+	RequestIP *requestIP `json:"request_ip,omitempty"`
+}
+
 // createTokenRequest is the body for POST .../tokens.
 type createTokenRequest struct {
-	Name      string   `json:"name"`
-	Policies  []policy `json:"policies"`
-	ExpiresOn string   `json:"expires_on,omitempty"`
+	Name      string          `json:"name"`
+	Policies  []policy        `json:"policies"`
+	Condition *tokenCondition `json:"condition,omitempty"`
+	ExpiresOn string          `json:"expires_on,omitempty"`
 }
 
 // tokenResult is the relevant subset of the create-token response.

--- a/path_creds.go
+++ b/path_creds.go
@@ -113,6 +113,12 @@ func (b *cloudflareBackend) pathCredsRead(ctx context.Context, req *logical.Requ
 		Policies:  policies,
 		ExpiresOn: time.Now().UTC().Add(backstop).Format(time.RFC3339),
 	}
+	if len(role.RequestIPIn) > 0 || len(role.RequestIPNotIn) > 0 {
+		tokenReq.Condition = &tokenCondition{RequestIP: &requestIP{
+			In:    role.RequestIPIn,
+			NotIn: role.RequestIPNotIn,
+		}}
+	}
 
 	token, err := client.createToken(ctx, scope, tokenReq)
 	if err != nil {

--- a/path_roles.go
+++ b/path_roles.go
@@ -15,20 +15,24 @@ import (
 // Cloudflare token context (account vs user) and the full policy set (ACL +
 // resources) that every generated token receives.
 type cloudflareRoleEntry struct {
-	TokenType string          `json:"token_type"`
-	AccountID string          `json:"account_id,omitempty"`
-	Policies  json.RawMessage `json:"policies"`
-	TTL       time.Duration   `json:"ttl"`
-	MaxTTL    time.Duration   `json:"max_ttl"`
+	TokenType      string          `json:"token_type"`
+	AccountID      string          `json:"account_id,omitempty"`
+	Policies       json.RawMessage `json:"policies"`
+	RequestIPIn    []string        `json:"request_ip_in,omitempty"`
+	RequestIPNotIn []string        `json:"request_ip_not_in,omitempty"`
+	TTL            time.Duration   `json:"ttl"`
+	MaxTTL         time.Duration   `json:"max_ttl"`
 }
 
 func (r *cloudflareRoleEntry) toResponseData() map[string]interface{} {
 	return map[string]interface{}{
-		"token_type": r.TokenType,
-		"account_id": r.AccountID,
-		"policies":   json.RawMessage(r.Policies),
-		"ttl":        int64(r.TTL.Seconds()),
-		"max_ttl":    int64(r.MaxTTL.Seconds()),
+		"token_type":        r.TokenType,
+		"account_id":        r.AccountID,
+		"policies":          json.RawMessage(r.Policies),
+		"request_ip_in":     r.RequestIPIn,
+		"request_ip_not_in": r.RequestIPNotIn,
+		"ttl":               int64(r.TTL.Seconds()),
+		"max_ttl":           int64(r.MaxTTL.Seconds()),
 	}
 }
 
@@ -55,6 +59,14 @@ func pathRole(b *cloudflareBackend) []*framework.Path {
 					Type:        framework.TypeString,
 					Description: `JSON array of Cloudflare token policies. Each policy has "effect" (default "allow"), "permission_groups" (each entry by {"id":...} or {"name":...}), and "resources" (the Cloudflare resource map).`,
 					Required:    true,
+				},
+				"request_ip_in": {
+					Type:        framework.TypeCommaStringSlice,
+					Description: "Optional client-IP allow list (IPv4/IPv6 CIDRs). The token is only valid from these addresses.",
+				},
+				"request_ip_not_in": {
+					Type:        framework.TypeCommaStringSlice,
+					Description: "Optional client-IP deny list (IPv4/IPv6 CIDRs). The token is rejected from these addresses.",
 				},
 				"ttl": {
 					Type:        framework.TypeDurationSecond,
@@ -154,6 +166,13 @@ func (b *cloudflareBackend) pathRolesWrite(ctx context.Context, req *logical.Req
 		role.Policies = canonical
 	} else if createOperation {
 		return logical.ErrorResponse("missing policies"), nil
+	}
+
+	if v, ok := d.GetOk("request_ip_in"); ok {
+		role.RequestIPIn = v.([]string)
+	}
+	if v, ok := d.GetOk("request_ip_not_in"); ok {
+		role.RequestIPNotIn = v.([]string)
 	}
 
 	if v, ok := d.GetOk("ttl"); ok {

--- a/path_roles_ip_test.go
+++ b/path_roles_ip_test.go
@@ -1,0 +1,79 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestRoleRequestIPRoundTrip verifies the client-IP restriction is stored on the
+// role and surfaced on read.
+func TestRoleRequestIPRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b, err := Factory(ctx, conf)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+
+	if _, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/ip-test",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"token_type":        tokenTypeAccount,
+			"policies":          `[{"permission_groups":[{"name":"Account Settings Read"}],"resources":{"com.cloudflare.api.account.x":"*"}}]`,
+			"request_ip_in":     "203.0.113.0/24,2001:db8::/32",
+			"request_ip_not_in": "203.0.113.7/32",
+		},
+	}); err != nil {
+		t.Fatalf("role write: %v", err)
+	}
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "role/ip-test",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatalf("role read: %v", err)
+	}
+	if got := resp.Data["request_ip_in"].([]string); !reflect.DeepEqual(got, []string{"203.0.113.0/24", "2001:db8::/32"}) {
+		t.Fatalf("request_ip_in = %v", got)
+	}
+	if got := resp.Data["request_ip_not_in"].([]string); !reflect.DeepEqual(got, []string{"203.0.113.7/32"}) {
+		t.Fatalf("request_ip_not_in = %v", got)
+	}
+}
+
+// TestCreateTokenRequestConditionOmitted confirms the condition is omitted from
+// the JSON body when no IP restriction is set, and present when it is.
+func TestCreateTokenRequestConditionOmitted(t *testing.T) {
+	noCond, _ := json.Marshal(&createTokenRequest{Name: "n", Policies: []policy{}})
+	if got := string(noCond); contains(got, "condition") {
+		t.Fatalf("expected no condition key, got %s", got)
+	}
+
+	withCond, _ := json.Marshal(&createTokenRequest{
+		Name:      "n",
+		Policies:  []policy{},
+		Condition: &tokenCondition{RequestIP: &requestIP{In: []string{"203.0.113.0/24"}}},
+	})
+	if got := string(withCond); !contains(got, `"request_ip":{"in":["203.0.113.0/24"]}`) {
+		t.Fatalf("expected request_ip in body, got %s", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/site/index.html
+++ b/site/index.html
@@ -116,6 +116,21 @@
     </div>
 
     <div class="card" style="margin-top:20px">
+      <h2>Token IP restriction <span class="hint">(optional)</span></h2>
+      <div class="row">
+        <div class="field">
+          <label for="ipIn">Allow IPs <span class="hint">request_ip_in</span></label>
+          <input type="text" id="ipIn" placeholder="203.0.113.0/24, 2001:db8::/32" />
+        </div>
+        <div class="field">
+          <label for="ipNotIn">Deny IPs <span class="hint">request_ip_not_in</span></label>
+          <input type="text" id="ipNotIn" placeholder="198.51.100.7/32" />
+        </div>
+      </div>
+      <p class="note" style="margin:0">Comma-separated IPv4/IPv6 CIDRs. Applied to the whole token via Cloudflare's <code class="k">condition.request_ip</code>.</p>
+    </div>
+
+    <div class="card" style="margin-top:20px">
       <div class="out-head">
         <h2>Policies</h2>
         <button class="primary tiny" id="addPolicy">+ Add policy</button>
@@ -143,9 +158,10 @@
       <p class="note">
         Permission groups may be given by <code class="k">name</code> or 32-hex
         <code class="k">id</code>; the plugin resolves names against Cloudflare's
-        live catalog when a token is minted. The list here is a convenience
-        subset — type any exact name in the custom field for anything not shown.
+        live catalog when a token is minted. Type any exact name in the custom
+        field for anything not listed.
       </p>
+      <p class="note" id="catalogNote">Using the built-in curated permission-group list.</p>
     </div>
   </section>
 </main>
@@ -201,10 +217,10 @@
 </template>
 
 <script>
-// Curated permission-group catalog (names + scope), grounded in Cloudflare's
-// token permission_groups API. Names must match Cloudflare exactly; the plugin
-// resolves them to IDs at generation time.
-const PERMISSION_GROUPS = {
+// Curated fallback catalog (names + scope), used when the full list generated
+// at build time (permission_groups.json) is unavailable. Names must match
+// Cloudflare exactly; the plugin resolves them to IDs at generation time.
+const CURATED = {
   "Account": [
     "Account Settings Read", "Account Settings Write",
     "Account Rulesets Read", "Account Rulesets Write",
@@ -242,6 +258,43 @@ const PERMISSION_GROUPS = {
 const q = (s, r = document) => r.querySelector(s);
 const qa = (s, r = document) => [...r.querySelectorAll(s)];
 
+// Active catalog: starts as the curated fallback, replaced by the full list
+// (fetched from permission_groups.json, generated at deploy time) when present.
+let CATALOG = CURATED;
+
+// Map a permission group's Cloudflare scopes to a display bucket.
+function scopeLabel(scopes) {
+  const s = scopes || [];
+  if (s.includes("com.cloudflare.api.account.zone")) return "Zone";
+  if (s.includes("com.cloudflare.edge.r2.bucket")) return "R2";
+  if (s.includes("com.cloudflare.api.user")) return "User";
+  if (s.includes("com.cloudflare.api.account")) return "Account";
+  return "Other";
+}
+
+// Load the full catalog generated at build time, if available.
+async function loadCatalog() {
+  try {
+    const res = await fetch("./permission_groups.json", { cache: "no-store" });
+    if (!res.ok) return;
+    const list = await res.json();
+    if (!Array.isArray(list) || list.length === 0) return;
+    const grouped = {};
+    for (const g of list) {
+      if (!g || !g.name) continue;
+      const bucket = scopeLabel(g.scopes);
+      (grouped[bucket] ||= new Set()).add(g.name);
+    }
+    const order = ["Account", "Zone", "User", "R2", "Other"];
+    const out = {};
+    for (const k of order) if (grouped[k]) out[k] = [...grouped[k]].sort((a, b) => a.localeCompare(b));
+    if (Object.keys(out).length) {
+      CATALOG = out;
+      q("#catalogNote").textContent = `Loaded ${list.length} permission groups from Cloudflare.`;
+    }
+  } catch (_) { /* keep curated fallback */ }
+}
+
 function makeResourceRow() {
   const node = q("#resourceTpl").content.firstElementChild.cloneNode(true);
   const rtype = node.querySelector(".rtype");
@@ -270,7 +323,7 @@ function makePolicy() {
   const box = node.querySelector(".pg-box");
 
   // Render grouped permission-group checkboxes.
-  for (const [scope, names] of Object.entries(PERMISSION_GROUPS)) {
+  for (const [scope, names] of Object.entries(CATALOG)) {
     const h = document.createElement("div");
     h.className = "pg-scope";
     h.textContent = scope + " scoped";
@@ -353,10 +406,15 @@ function refresh() {
 
   q("#jsonOut").textContent = JSON.stringify(policies, null, 2);
 
+  const ipIn = q("#ipIn").value.trim();
+  const ipNotIn = q("#ipNotIn").value.trim();
+
   const compact = JSON.stringify(policies);
   let cmd = `vault write cloudflare/role/${roleName} \\\n  token_type=${tokenType} \\\n`;
   if (ttl) cmd += `  ttl=${ttl} \\\n`;
   if (maxTtl) cmd += `  max_ttl=${maxTtl} \\\n`;
+  if (ipIn) cmd += `  request_ip_in="${ipIn}" \\\n`;
+  if (ipNotIn) cmd += `  request_ip_not_in="${ipNotIn}" \\\n`;
   cmd += `  policies='${compact}'`;
   q("#cmdOut").textContent = cmd;
 
@@ -378,16 +436,15 @@ qa("[data-copy]").forEach(btn => btn.addEventListener("click", async () => {
   catch { /* clipboard unavailable */ }
 }));
 
-// Seed one policy mirroring the README example.
-q("#policies").appendChild(makePolicy());
-(function seed() {
+// Seed one policy mirroring the README example, after the catalog loads.
+(async function init() {
+  await loadCatalog();
+  q("#policies").appendChild(makePolicy());
   const pol = q(".policy");
   qa(".pg", pol).forEach(c => { if (c.value === "DNS Write" || c.value === "Zone Read") c.checked = true; });
-  const r = pol.querySelector(".resource");
-  r.querySelector(".rtype").value = "zone";
-  r.querySelector(".rid").value = "";
+  pol.querySelector(".rtype").value = "zone";
+  refresh();
 })();
-refresh();
 </script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,393 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Policy Builder · vault-cloudflare-secret-engine</title>
+<meta name="description" content="Build the policies JSON and vault write command for a vault-cloudflare-secret-engine role." />
+<style>
+  :root {
+    --bg: #ffffff; --panel: #f6f7f9; --border: #e3e6ea; --text: #1d2733;
+    --muted: #5b6775; --accent: #f6821f; --accent-fg: #ffffff;
+    --code-bg: #0d1117; --code-fg: #e6edf3; --danger: #d23f3f; --ok: #1a8c4a;
+    --radius: 10px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f141a; --panel: #161c24; --border: #2a323d; --text: #e6edf3;
+      --muted: #9aa7b4; --code-bg: #0b0f14; --code-fg: #e6edf3;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  header {
+    border-bottom: 1px solid var(--border); padding: 20px 24px;
+    display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+  }
+  header .dot { width: 10px; height: 26px; background: var(--accent); border-radius: 3px; }
+  header h1 { font-size: 18px; margin: 0; font-weight: 650; }
+  header p { margin: 0; color: var(--muted); font-size: 13px; }
+  header .spacer { flex: 1; }
+  header a { color: var(--accent); text-decoration: none; font-size: 13px; }
+  main { max-width: 1100px; margin: 0 auto; padding: 24px; display: grid; gap: 20px; grid-template-columns: 1fr; }
+  @media (min-width: 940px) { main { grid-template-columns: 1.05fr 0.95fr; align-items: start; } }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px; }
+  .card h2 { font-size: 14px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 0 0 14px; }
+  label { display: block; font-size: 13px; font-weight: 600; margin: 0 0 5px; }
+  .hint { color: var(--muted); font-size: 12px; font-weight: 400; }
+  input[type=text], select, textarea {
+    width: 100%; padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px;
+    background: var(--bg); color: var(--text); font: inherit;
+  }
+  .row { display: grid; gap: 12px; grid-template-columns: 1fr 1fr; }
+  .field { margin-bottom: 14px; }
+  button {
+    font: inherit; border: 1px solid var(--border); background: var(--bg); color: var(--text);
+    padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  }
+  button:hover { border-color: var(--accent); }
+  button.primary { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+  button.link { border: none; background: none; color: var(--accent); padding: 4px; }
+  button.tiny { padding: 3px 8px; font-size: 12px; }
+  .policy { border: 1px dashed var(--border); border-radius: var(--radius); padding: 14px; margin-bottom: 14px; }
+  .policy-head { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+  .policy-head .n { font-weight: 650; }
+  .pg-search { margin-bottom: 8px; }
+  .pg-box { max-height: 230px; overflow: auto; border: 1px solid var(--border); border-radius: 8px; padding: 8px; background: var(--bg); }
+  .pg-scope { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 8px 4px 4px; }
+  .pg-item { display: flex; align-items: center; gap: 8px; padding: 3px 4px; font-size: 13px; }
+  .pg-item input { width: auto; }
+  .resource { display: grid; grid-template-columns: 150px 1fr auto; gap: 8px; align-items: start; margin-bottom: 8px; }
+  .resource .preview { grid-column: 1 / -1; font-size: 11px; color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
+  pre {
+    background: var(--code-bg); color: var(--code-fg); padding: 14px; border-radius: 8px;
+    overflow: auto; font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin: 0;
+  }
+  .out-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+  .out-head h2 { margin: 0; }
+  .sticky { position: sticky; top: 16px; }
+  .warn { color: var(--danger); font-size: 13px; margin-top: 8px; min-height: 18px; }
+  .ok { color: var(--ok); }
+  .note { font-size: 12px; color: var(--muted); margin-top: 10px; }
+  code.k { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: var(--bg); padding: 1px 5px; border-radius: 5px; border: 1px solid var(--border); }
+</style>
+</head>
+<body>
+<header>
+  <div class="dot"></div>
+  <div>
+    <h1>Cloudflare role policy builder</h1>
+    <p>Generate the <code class="k">policies</code> JSON and <code class="k">vault write</code> command for a role.</p>
+  </div>
+  <div class="spacer"></div>
+  <a href="https://github.com/kalw/vault-cloudflare-secret-engine" target="_blank" rel="noopener">GitHub ↗</a>
+</header>
+
+<main>
+  <section>
+    <div class="card">
+      <h2>Role</h2>
+      <div class="row">
+        <div class="field">
+          <label for="roleName">Role name</label>
+          <input type="text" id="roleName" value="dns-editor" />
+        </div>
+        <div class="field">
+          <label for="tokenType">Token type <span class="hint">(context)</span></label>
+          <select id="tokenType">
+            <option value="account">account — service-tied</option>
+            <option value="user">user — tied to the parent user</option>
+          </select>
+        </div>
+      </div>
+      <div class="row">
+        <div class="field">
+          <label for="ttl">ttl <span class="hint">(optional)</span></label>
+          <input type="text" id="ttl" placeholder="e.g. 30m" />
+        </div>
+        <div class="field">
+          <label for="maxTtl">max_ttl <span class="hint">(optional)</span></label>
+          <input type="text" id="maxTtl" placeholder="e.g. 2h" />
+        </div>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:20px">
+      <div class="out-head">
+        <h2>Policies</h2>
+        <button class="primary tiny" id="addPolicy">+ Add policy</button>
+      </div>
+      <div id="policies"></div>
+    </div>
+  </section>
+
+  <section class="sticky">
+    <div class="card">
+      <div class="out-head">
+        <h2>policies JSON</h2>
+        <button class="link" data-copy="jsonOut">Copy</button>
+      </div>
+      <pre id="jsonOut"></pre>
+      <div class="warn" id="warn"></div>
+    </div>
+
+    <div class="card" style="margin-top:20px">
+      <div class="out-head">
+        <h2>vault command</h2>
+        <button class="link" data-copy="cmdOut">Copy</button>
+      </div>
+      <pre id="cmdOut"></pre>
+      <p class="note">
+        Permission groups may be given by <code class="k">name</code> or 32-hex
+        <code class="k">id</code>; the plugin resolves names against Cloudflare's
+        live catalog when a token is minted. The list here is a convenience
+        subset — type any exact name in the custom field for anything not shown.
+      </p>
+    </div>
+  </section>
+</main>
+
+<!-- Resource row template -->
+<template id="resourceTpl">
+  <div class="resource">
+    <select class="rtype">
+      <option value="zone">Specific zone</option>
+      <option value="account">Whole account</option>
+      <option value="allzones">All zones in account</option>
+      <option value="user">User</option>
+      <option value="custom">Custom…</option>
+    </select>
+    <input type="text" class="rid" placeholder="zone ID" />
+    <input type="text" class="rkey" placeholder="resource key" style="display:none" />
+    <input type="text" class="rval" placeholder='value ("*" or JSON)' style="display:none" />
+    <button class="tiny rdel" title="Remove resource">✕</button>
+    <div class="preview"></div>
+  </div>
+</template>
+
+<!-- Policy template -->
+<template id="policyTpl">
+  <div class="policy">
+    <div class="policy-head">
+      <span class="n">Policy</span>
+      <select class="effect" style="width:auto">
+        <option value="allow">allow</option>
+        <option value="deny">deny</option>
+      </select>
+      <div class="spacer" style="flex:1"></div>
+      <button class="tiny pdel" title="Remove policy">Remove</button>
+    </div>
+
+    <div class="field">
+      <label>Permission groups</label>
+      <input type="text" class="pg-search" placeholder="Filter permission groups…" />
+      <div class="pg-box"></div>
+    </div>
+
+    <div class="field">
+      <label>Custom permission groups <span class="hint">comma-separated names or 32-hex IDs</span></label>
+      <input type="text" class="customGroups" placeholder="e.g. Stream Read, 4755a26eedb94da69e1066d98aa820be" />
+    </div>
+
+    <div class="field">
+      <label>Resources</label>
+      <div class="resources"></div>
+      <button class="tiny addResource">+ Add resource</button>
+    </div>
+  </div>
+</template>
+
+<script>
+// Curated permission-group catalog (names + scope), grounded in Cloudflare's
+// token permission_groups API. Names must match Cloudflare exactly; the plugin
+// resolves them to IDs at generation time.
+const PERMISSION_GROUPS = {
+  "Account": [
+    "Account Settings Read", "Account Settings Write",
+    "Account Rulesets Read", "Account Rulesets Write",
+    "Account API Tokens Read", "Account API Tokens Write",
+    "Billing Read",
+    "Workers Scripts Read", "Workers Scripts Write",
+    "Workers KV Storage Read", "Workers KV Storage Write",
+    "Workers R2 Storage Read", "Workers R2 Storage Write",
+    "Load Balancing: Monitors and Pools Read", "Load Balancing: Monitors and Pools Write",
+    "Access: Apps and Policies Read", "Access: Apps and Policies Write",
+    "Access: Service Tokens Read", "Access: Service Tokens Write",
+    "Cloudflare Tunnel Read", "Cloudflare Tunnel Write",
+    "Logs Read"
+  ],
+  "Zone": [
+    "Zone Read",
+    "Zone Settings Read", "Zone Settings Write",
+    "DNS Read", "DNS Write",
+    "SSL and Certificates Read", "SSL and Certificates Write",
+    "Page Rules Read", "Page Rules Write",
+    "Cache Purge",
+    "Firewall Services Read", "Firewall Services Write",
+    "Zone WAF Read", "Zone WAF Write",
+    "Workers Routes Read", "Workers Routes Write",
+    "Transform Rules Read", "Transform Rules Write",
+    "Analytics Read"
+  ],
+  "User": [
+    "User Details Read", "User Details Write",
+    "Memberships Read",
+    "User API Tokens Read", "User API Tokens Write"
+  ]
+};
+
+const q = (s, r = document) => r.querySelector(s);
+const qa = (s, r = document) => [...r.querySelectorAll(s)];
+
+function makeResourceRow() {
+  const node = q("#resourceTpl").content.firstElementChild.cloneNode(true);
+  const rtype = node.querySelector(".rtype");
+  const rid = node.querySelector(".rid");
+  const rkey = node.querySelector(".rkey");
+  const rval = node.querySelector(".rval");
+  function sync() {
+    const t = rtype.value;
+    const custom = t === "custom";
+    rid.style.display = custom ? "none" : "";
+    rkey.style.display = custom ? "" : "none";
+    rval.style.display = custom ? "" : "none";
+    rid.placeholder =
+      t === "zone" ? "zone ID" :
+      t === "user" ? "user ID" : "account ID";
+    refresh();
+  }
+  rtype.addEventListener("change", sync);
+  node.querySelector(".rdel").addEventListener("click", () => { node.remove(); refresh(); });
+  sync();
+  return node;
+}
+
+function makePolicy() {
+  const node = q("#policyTpl").content.firstElementChild.cloneNode(true);
+  const box = node.querySelector(".pg-box");
+
+  // Render grouped permission-group checkboxes.
+  for (const [scope, names] of Object.entries(PERMISSION_GROUPS)) {
+    const h = document.createElement("div");
+    h.className = "pg-scope";
+    h.textContent = scope + " scoped";
+    box.appendChild(h);
+    for (const name of names) {
+      const wrap = document.createElement("label");
+      wrap.className = "pg-item";
+      wrap.dataset.name = name.toLowerCase();
+      const cb = document.createElement("input");
+      cb.type = "checkbox"; cb.className = "pg"; cb.value = name;
+      const span = document.createElement("span");
+      span.textContent = name;
+      wrap.append(cb, span);
+      box.appendChild(wrap);
+    }
+  }
+
+  // Filter
+  node.querySelector(".pg-search").addEventListener("input", (e) => {
+    const term = e.target.value.toLowerCase();
+    qa(".pg-item", box).forEach(it => {
+      it.style.display = it.dataset.name.includes(term) ? "" : "none";
+    });
+    qa(".pg-scope", box).forEach(s => { s.style.display = term ? "none" : ""; });
+  });
+
+  node.querySelector(".pdel").addEventListener("click", () => {
+    if (qa(".policy").length > 1) { node.remove(); refresh(); }
+  });
+  const resources = node.querySelector(".resources");
+  node.querySelector(".addResource").addEventListener("click", () => {
+    resources.appendChild(makeResourceRow()); refresh();
+  });
+  resources.appendChild(makeResourceRow());
+  return node;
+}
+
+function readResources(policyEl) {
+  const resources = {};
+  qa(".resource", policyEl).forEach(r => {
+    const t = r.querySelector(".rtype").value;
+    const id = (r.querySelector(".rid").value || "").trim();
+    const preview = r.querySelector(".preview");
+    let key = "", val = "*";
+    if (t === "account") key = "com.cloudflare.api.account." + id;
+    else if (t === "zone") key = "com.cloudflare.api.account.zone." + id;
+    else if (t === "user") key = "com.cloudflare.api.user." + id;
+    else if (t === "allzones") { key = "com.cloudflare.api.account." + id; val = { "com.cloudflare.api.account.zone.*": "*" }; }
+    else if (t === "custom") {
+      key = (r.querySelector(".rkey").value || "").trim();
+      const raw = (r.querySelector(".rval").value || "").trim();
+      try { val = raw.startsWith("{") ? JSON.parse(raw) : (raw || "*"); } catch { val = raw; }
+    }
+    if (t !== "custom" && !id) { preview.textContent = "↳ enter an ID"; return; }
+    if (!key) { preview.textContent = ""; return; }
+    resources[key] = val;
+    preview.textContent = "↳ " + JSON.stringify({ [key]: val });
+  });
+  return resources;
+}
+
+function refresh() {
+  const roleName = q("#roleName").value.trim() || "<role>";
+  const tokenType = q("#tokenType").value;
+  const ttl = q("#ttl").value.trim();
+  const maxTtl = q("#maxTtl").value.trim();
+  const warnings = [];
+
+  const policies = qa(".policy").map((pol, i) => {
+    const effect = pol.querySelector(".effect").value;
+    const groups = qa(".pg:checked", pol).map(c => ({ name: c.value }));
+    (pol.querySelector(".customGroups").value || "").split(",").map(s => s.trim()).filter(Boolean)
+      .forEach(g => groups.push(/^[0-9a-f]{32}$/i.test(g) ? { id: g } : { name: g }));
+    const resources = readResources(pol);
+
+    if (groups.length === 0) warnings.push(`Policy ${i + 1}: add at least one permission group.`);
+    if (Object.keys(resources).length === 0) warnings.push(`Policy ${i + 1}: add at least one resource.`);
+    return { effect, permission_groups: groups, resources };
+  });
+
+  q("#jsonOut").textContent = JSON.stringify(policies, null, 2);
+
+  const compact = JSON.stringify(policies);
+  let cmd = `vault write cloudflare/role/${roleName} \\\n  token_type=${tokenType} \\\n`;
+  if (ttl) cmd += `  ttl=${ttl} \\\n`;
+  if (maxTtl) cmd += `  max_ttl=${maxTtl} \\\n`;
+  cmd += `  policies='${compact}'`;
+  q("#cmdOut").textContent = cmd;
+
+  const warn = q("#warn");
+  warn.textContent = warnings.length ? warnings.join(" ") : "✓ ready";
+  warn.className = warnings.length ? "warn" : "warn ok";
+}
+
+// Recompute on any input across the form.
+document.addEventListener("input", refresh);
+document.addEventListener("change", refresh);
+
+q("#addPolicy").addEventListener("click", () => { q("#policies").appendChild(makePolicy()); refresh(); });
+
+// Copy buttons
+qa("[data-copy]").forEach(btn => btn.addEventListener("click", async () => {
+  const text = q("#" + btn.dataset.copy).textContent;
+  try { await navigator.clipboard.writeText(text); const o = btn.textContent; btn.textContent = "Copied!"; setTimeout(() => btn.textContent = o, 1200); }
+  catch { /* clipboard unavailable */ }
+}));
+
+// Seed one policy mirroring the README example.
+q("#policies").appendChild(makePolicy());
+(function seed() {
+  const pol = q(".policy");
+  qa(".pg", pol).forEach(c => { if (c.value === "DNS Write" || c.value === "Zone Read") c.checked = true; });
+  const r = pol.querySelector(".resource");
+  r.querySelector(".rtype").value = "zone";
+  r.querySelector(".rid").value = "";
+})();
+refresh();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

A static **policy builder** so users don't hand-write the `policies` JSON. Hosted on GitHub Pages, no install or backend.

### `site/index.html` (dependency-free)
- Pick **permission groups** from a curated Cloudflare catalog grouped by scope (Account / Zone / User), searchable, plus a custom field that accepts any exact **name** or 32-hex **id** (auto-detected).
- Build **resources** with helpers for each shape the plugin supports: specific zone, whole account, all-zones-in-account (nested), user, or custom key/value.
- Multiple policies, `allow`/`deny`, optional `ttl`/`max_ttl`.
- Live output: pretty `policies` JSON **and** the full `vault write cloudflare/role/<name> …` command, each with a copy button, plus inline validation.

Grounded in the Cloudflare token `permission_groups` API (names/scopes from the live spec). Because the plugin resolves names→IDs at generation time, the page outputs `{"name": "…"}` and stays correct without baking volatile IDs.

### `.github/workflows/pages.yml`
Publishes `site/` to Pages via `actions/deploy-pages` on changes to `site/**`.

## Action required after merge
Enable Pages: **repo Settings → Pages → Source = "GitHub Actions"**. The site will be at `https://kalw.github.io/vault-cloudflare-secret-engine/`.

## Verification
Built locally and driven via a headless preview: checking *Zone Read* + *DNS Write* with a zone resource yields the exact README example; the nested all-zones resource and name-vs-id detection both produce correct JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)