### PR TITLE
ci: fix auto-release GoReleaser failure (lightweight tags)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
           default_bump: false
+          dry_run: true # compute only; we create a lightweight tag ourselves
+      - name: Create and push tag
+        if: steps.tag.outputs.new_tag != ''
+        run: |
+          # A lightweight tag on HEAD — GoReleaser requires the current tag to
+          # point at the built commit, which annotated tags from the action break.
+          git tag "${{ steps.tag.outputs.new_tag }}"
+          git push origin "${{ steps.tag.outputs.new_tag }}"
       - uses: actions/setup-go@v5
         if: steps.tag.outputs.new_tag != ''
         with:


### PR DESCRIPTION
## Problem

The first `feat:` merge to main triggered the `auto` release path, which failed:

```
⨯ release failed: git tag v1.1.0 was not made against commit 07f3221…
```

`mathieudutour/github-tag-action` creates an **annotated** tag. GoReleaser's "current tag must point at the built commit" check trips on annotated tag objects, so the in-job `auto` build fails. (The `tagged` job is unaffected because it checks out the tag ref directly — that's how v1.0.0 built.)

## Fix

Run the action in `dry_run: true` (compute the version only), then create a **lightweight** tag on HEAD ourselves and push it before GoReleaser runs. Lightweight tag → `rev-list v1.1.0 == HEAD` → GoReleaser is happy.

## Note

`v1.1.0` itself was already published out-of-band by re-pushing the tag through the working `tagged` job, so this PR only prevents the failure from recurring on the next `feat:`/`fix:` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)