### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
@@ -34,8 +34,8 @@ jobs:
         goos: [linux, darwin, freebsd, openbsd]
         goarch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
@@ -53,8 +53,8 @@ jobs:
     # Never expose secrets to pull requests from forks.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5
       - name: Generate permission group catalog
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean
@@ -44,7 +44,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Compute next version (Conventional Commits)
@@ -62,12 +62,12 @@ jobs:
           # point at the built commit, which annotated tags from the action break.
           git tag "${{ steps.tag.outputs.new_tag }}"
           git push origin "${{ steps.tag.outputs.new_tag }}"
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         if: steps.tag.outputs.new_tag != ''
         with:
           go-version: "1.25"
           cache: true
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         if: steps.tag.outputs.new_tag != ''
         with:
           version: "~> v2"


### PR DESCRIPTION
Moves off the Node 20 runtime GitHub deprecated (forced to Node 24 after 2026-06-16, removed 2026-09-16):

- `actions/checkout` v4 → **v6**
- `actions/setup-go` v5 → **v6**
- `goreleaser/goreleaser-action` v6 → **v7** (still pulls GoReleaser `~> v2`)

`mathieudutour/github-tag-action` stays at `v6.2` — it's the latest release, so its Node 20 warning will persist until upstream ships a Node 24 build. The GitHub-owned Pages actions weren't flagged and are already current.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)