### PR TITLE
build: realign Go module path to github.com/kalw

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://github.com/kalw/vault-cloudflare-secret-engine/actions/workflows/release.yml/badge.svg)](https://github.com/kalw/vault-cloudflare-secret-engine/actions/workflows/release.yml)
 [![Latest release](https://img.shields.io/github/v/release/kalw/vault-cloudflare-secret-engine?sort=semver&logo=github)](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest)
 [![Go version](https://img.shields.io/github/go-mod/go-version/kalw/vault-cloudflare-secret-engine?logo=go)](go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kalw/vault-cloudflare-secret-engine)](https://goreportcard.com/report/github.com/kalw/vault-cloudflare-secret-engine)
 
 **Platforms** — cross-compiled in CI and published each release (`amd64` · `arm64`):
 [![linux](https://img.shields.io/badge/linux-amd64%20%C2%B7%20arm64-FCC624?logo=linux&logoColor=black)](https://github.com/kalw/vault-cloudflare-secret-engine/releases/latest)

--- a/cmd/vault-cloudflare-secret-engine/main.go
+++ b/cmd/vault-cloudflare-secret-engine/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	cloudflaresecrets "github.com/arcdigital/vault-cloudflare-secret-engine"
+	cloudflaresecrets "github.com/kalw/vault-cloudflare-secret-engine"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/arcdigital/vault-cloudflare-secret-engine
+module github.com/kalw/vault-cloudflare-secret-engine
 
 go 1.25.7
 


### PR DESCRIPTION
The module path was `github.com/arcdigital/vault-cloudflare-secret-engine` while the repo is `github.com/kalw/vault-cloudflare-secret-engine`. That mismatch broke `go install github.com/kalw/...@latest`, pkg.go.dev, and Go Report Card.

- `go.mod`: module path → `github.com/kalw/...`
- `cmd/.../main.go`: import → `github.com/kalw/...`
- README: add the now-valid Go Report Card badge

`go build`, `go vet`, `go test ./...` all pass under the new path.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)