### PR TITLE
Security & design hardening: idempotent revoke, input validation, root rotation, R2 creds (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,9 @@
 # GoReleaser build output
 /dist/
 
+# Local test credentials (never commit real Cloudflare tokens)
+*.env
+cf-test.env
+
 # Generated at deploy time by the Pages workflow
 site/permission_groups.json

--- a/README.md
+++ b/README.md
@@ -176,6 +176,34 @@ the effective `max_ttl` is also set as a backstop in case Vault never revokes.
 Because generation is gated on `cloudflare/creds/<role>`, the standard Vault ACL
 system restricts which identities may use which roles.
 
+### R2 S3 credentials
+
+For roles whose policies grant R2 permissions, set `r2_s3_credentials=true` and
+the `creds` response additionally returns an S3-compatible keypair derived from
+the token, ready for R2's S3 API:
+
+```text
+$ vault write cloudflare/role/r2-objects \
+    token_type="account" \
+    r2_s3_credentials=true \
+    policies='[{"permission_groups":[{"name":"Workers R2 Storage Bucket Item Write"}],
+                "resources":{"com.cloudflare.api.account.<account-id>":"*"}}]'
+
+$ vault read cloudflare/creds/r2-objects
+Key                     Value
+---                     -----
+token                   v1.0-...
+token_id                <id>
+r2_access_key_id        <id>                # = token_id
+r2_secret_access_key    <64-hex>            # = SHA-256(token value)
+r2_endpoint             https://<account-id>.r2.cloudflarestorage.com
+...
+```
+
+Point any S3 client (region `auto`) at `r2_endpoint` with that keypair. The
+credentials are the token, so revoking the lease deletes the token and
+invalidates them.
+
 ### Rotating the parent token
 
 The parent credential can be rotated in place so it is owned and rolled by

--- a/README.md
+++ b/README.md
@@ -176,6 +176,50 @@ the effective `max_ttl` is also set as a backstop in case Vault never revokes.
 Because generation is gated on `cloudflare/creds/<role>`, the standard Vault ACL
 system restricts which identities may use which roles.
 
+### Rotating the parent token
+
+The parent credential can be rotated in place so it is owned and rolled by
+Vault rather than being a static long-lived secret:
+
+```text
+$ vault write -f cloudflare/config/rotate-root token_type=account
+Key         Value
+---         -----
+rotated     true
+token_id    <parent-token-id>
+token_type  account
+```
+
+This rolls the configured parent token's **value** via the Cloudflare API and
+stores the new value; the token's ID and permissions are unchanged, and the new
+value is never returned. Use `token_type=user` to rotate the user-context
+parent. Only a top-level token that holds *API Tokens · Write* can roll itself,
+which is exactly what the parent token needs to be — Cloudflare does not allow a
+token minted through the API to hold token-management permissions, so rotation
+preserves the existing token rather than creating a replacement.
+
+## Security model
+
+Read this before pointing the engine at a production account.
+
+- **`role/*` write access equals the parent token's full authority.** A role's
+  `policies` are passed to Cloudflare as-is; the plugin does not cap them to a
+  subset. Anyone who can write a role can mint a token with any privilege the
+  parent token can grant, up to whole-account scope. Restrict write access to
+  `role/*` (and `config`) with Vault ACLs as tightly as you would the parent
+  token itself.
+- **Scope the parent token down.** The parent token's Cloudflare permissions are
+  the real privilege ceiling of the mount. Grant it only the permission groups
+  and resources that roles on this mount should ever hand out (plus
+  *API Tokens · Write* so it can mint, revoke, and rotate). Do not reuse a broad
+  account-admin token.
+- **One mount per trust boundary.** All roles on a mount share one parent
+  credential, so they share its reach. For separate tenants/accounts, use
+  separate mounts, each with a parent token scoped to just that tenant.
+- **Rotate the parent token** after seeding it (see above) and on a schedule, so
+  a leaked or operator-retained bootstrap value does not stay valid
+  indefinitely.
+
 ## Local Development
 
 ### Build the code

--- a/acceptance_r2_test.go
+++ b/acceptance_r2_test.go
@@ -1,0 +1,94 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestAcceptance_R2Credentials mints an R2-scoped token through the backend
+// against the live Cloudflare API and verifies the derived S3 keypair. It does
+// not exercise the S3 data plane itself (that needs no plugin code and would
+// add an S3 client dependency); the derived keypair has been confirmed to work
+// against a real R2 bucket out-of-band. [M11]
+//
+// Requires: VAULT_ACC=1, CLOUDFLARE_TEST_R2=1, CLOUDFLARE_ACCOUNT_ID,
+// CLOUDFLARE_API_TOKEN (holding a "Workers R2 Storage ... Write" group so it can
+// grant it), and R2 enabled on the account.
+func TestAcceptance_R2Credentials(t *testing.T) {
+	if os.Getenv("VAULT_ACC") == "" {
+		t.Skip("acceptance test; set VAULT_ACC=1 to run")
+	}
+	if os.Getenv("CLOUDFLARE_TEST_R2") == "" {
+		t.Skip("set CLOUDFLARE_TEST_R2=1 (with R2 enabled and an R2-capable parent token) to run")
+	}
+	accountID := requireEnv(t, "CLOUDFLARE_ACCOUNT_ID")
+	parentToken := requireEnv(t, "CLOUDFLARE_API_TOKEN")
+	ctx := context.Background()
+
+	accScope := tokenScope{Type: tokenTypeAccount, AccountID: accountID}
+	pgs, err := newCloudflareClient(parentToken).listPermissionGroups(ctx, accScope)
+	if err != nil {
+		t.Fatalf("list permission groups: %v", err)
+	}
+	var r2WriteID string
+	for _, pg := range pgs {
+		if strings.Contains(pg.Name, "R2 Storage") && strings.Contains(pg.Name, "Write") {
+			r2WriteID = pg.ID
+			break
+		}
+	}
+	if r2WriteID == "" {
+		t.Skip("parent token cannot grant an R2 storage write group")
+	}
+
+	b, storage := newTestBackendWithAPI(t, "") // real API
+	mustWrite(t, ctx, b, storage, "config", map[string]interface{}{
+		"cloudflare_account_id": accountID,
+		"cloudflare_api_token":  parentToken,
+	})
+	mustWrite(t, ctx, b, storage, "role/r2", map[string]interface{}{
+		"token_type":        "account",
+		"policies":          fmt.Sprintf(`[{"permission_groups":[{"id":"%s"}],"resources":{"com.cloudflare.api.account.%s":"*"}}]`, r2WriteID, accountID),
+		"r2_s3_credentials": true,
+		"ttl":               "5m",
+		"max_ttl":           "10m",
+	})
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.ReadOperation, Path: "creds/r2", Storage: storage,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("creds/r2: err=%v resp=%v", err, resp)
+	}
+	// Always revoke the minted token.
+	t.Cleanup(func() {
+		_, _ = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.RevokeOperation, Path: "creds/r2", Storage: storage, Secret: resp.Secret,
+		})
+	})
+
+	tokenValue, _ := resp.Data["token"].(string)
+	tokenID, _ := resp.Data["token_id"].(string)
+	ak, _ := resp.Data["r2_access_key_id"].(string)
+	sk, _ := resp.Data["r2_secret_access_key"].(string)
+	ep, _ := resp.Data["r2_endpoint"].(string)
+
+	if ak != tokenID {
+		t.Fatalf("r2_access_key_id (%s) must equal token_id (%s)", ak, tokenID)
+	}
+	if sk != r2SecretAccessKey(tokenValue) {
+		t.Fatal("r2_secret_access_key is not the SHA-256 of the token value")
+	}
+	if !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(sk) {
+		t.Fatalf("r2_secret_access_key is not 64-char hex: %q", sk)
+	}
+	if want := r2Endpoint(accountID); ep != want {
+		t.Fatalf("r2_endpoint = %q, want %q", ep, want)
+	}
+}

--- a/acceptance_rotate_test.go
+++ b/acceptance_rotate_test.go
@@ -1,0 +1,75 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestAcceptance_RotateRoot validates config/rotate-root against the live
+// Cloudflare API through the real handler path.
+//
+// It is DESTRUCTIVE and opt-in: rotate-root rolls the configured parent token's
+// value in place, and the plugin deliberately never returns that new value, so
+// after this test the token supplied via CLOUDFLARE_API_TOKEN is invalidated and
+// its new value is only recoverable from Vault storage. Run it ONLY with a
+// throwaway token you are willing to discard.
+//
+// Requires: VAULT_ACC=1, CLOUDFLARE_ROTATE_ROOT_DESTRUCTIVE=1,
+// CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN (a top-level token holding
+// "API Tokens Write" — only such a token can roll itself; a token minted via the
+// API cannot, as Cloudflare forbids sub-tokens from managing tokens).
+func TestAcceptance_RotateRoot(t *testing.T) {
+	if os.Getenv("VAULT_ACC") == "" {
+		t.Skip("acceptance test; set VAULT_ACC=1 to run")
+	}
+	if os.Getenv("CLOUDFLARE_ROTATE_ROOT_DESTRUCTIVE") == "" {
+		t.Skip("destructive: rolls (and thus invalidates) CLOUDFLARE_API_TOKEN; set CLOUDFLARE_ROTATE_ROOT_DESTRUCTIVE=1 with a disposable token to run")
+	}
+
+	accountID := requireEnv(t, "CLOUDFLARE_ACCOUNT_ID")
+	parentToken := requireEnv(t, "CLOUDFLARE_API_TOKEN")
+	ctx := context.Background()
+
+	// Record the parent token's own ID so we can assert rotate-root targets it.
+	wantID, err := newCloudflareClient(parentToken).verifyToken(ctx, tokenScope{Type: tokenTypeAccount, AccountID: accountID})
+	if err != nil {
+		t.Fatalf("verify parent token: %v", err)
+	}
+
+	b, storage := newTestBackendWithAPI(t, "") // "" => real Cloudflare API
+	mustWrite(t, ctx, b, storage, "config", map[string]interface{}{
+		"cloudflare_account_id": accountID,
+		"cloudflare_api_token":  parentToken,
+	})
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/rotate-root",
+		Storage:   storage,
+		Data:      map[string]interface{}{"token_type": tokenTypeAccount},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("rotate-root: err=%v resp=%v", err, resp)
+	}
+	if resp.Data["token_id"] != wantID {
+		t.Fatalf("rotate-root token_id=%v, want %s", resp.Data["token_id"], wantID)
+	}
+
+	// The old value must no longer verify; the persisted new value must work,
+	// proven by a second rotation succeeding through the backend.
+	if _, err := newCloudflareClient(parentToken).verifyToken(ctx, tokenScope{Type: tokenTypeAccount, AccountID: accountID}); err == nil {
+		t.Fatal("old parent token still verifies after rotation")
+	}
+	resp2, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/rotate-root",
+		Storage:   storage,
+		Data:      map[string]interface{}{"token_type": tokenTypeAccount},
+	})
+	if err != nil || (resp2 != nil && resp2.IsError()) {
+		t.Fatalf("second rotate-root (persisted new value must work): err=%v resp=%v", err, resp2)
+	}
+}

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -122,11 +122,13 @@ func runLifecycle(t *testing.T, accountID, parentToken, tokenType, policies stri
 		t.Fatalf("revoke: err=%v resp=%v", err, revResp)
 	}
 
-	// 5. Confirm the token is gone: deleting it again should fail.
+	// 5. Confirm graceful cleanup: revocation is idempotent. The token is
+	// already gone (deleted by step 4), so Cloudflare returns 404, which
+	// deleteToken must treat as success rather than a hard error.
 	client := newCloudflareClient(parentToken)
 	scope := tokenScope{Type: tokenType, AccountID: accountID}
-	if err := client.deleteToken(ctx, scope, tokenID); err == nil {
-		t.Fatal("expected second delete to fail (token should already be revoked)")
+	if err := client.deleteToken(ctx, scope, tokenID); err != nil {
+		t.Fatalf("second delete of an already-revoked token must be idempotent, got: %v", err)
 	}
 }
 

--- a/backend.go
+++ b/backend.go
@@ -9,6 +9,11 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+// PluginVersion is the running plugin version reported to Vault (shown by
+// `vault plugin list` and used for pinning). It is set by the main package from
+// build-time metadata; empty means unversioned.
+var PluginVersion string
+
 // Factory returns a configured Cloudflare secrets backend. It is the entry
 // point referenced by the plugin's main package.
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
@@ -66,27 +71,11 @@ func newBackend() *cloudflareBackend {
 			SealWrapStorage: []string{configStoragePath},
 		},
 	}
+	if PluginVersion != "" {
+		b.Backend.RunningVersion = PluginVersion
+	}
 
 	return b
-}
-
-// clientForTokenType loads the config and builds a Cloudflare client using the
-// parent credential for the requested token context (account or user). It fails
-// with a clear error when that context's credentials are not configured.
-func (b *cloudflareBackend) clientForTokenType(ctx context.Context, s logical.Storage, tokenType string) (*cloudflareClient, error) {
-	config, err := getConfig(ctx, s)
-	if err != nil {
-		return nil, err
-	}
-	if config == nil {
-		return nil, errBackendNotConfigured
-	}
-
-	token, err := config.parentTokenFor(tokenType)
-	if err != nil {
-		return nil, err
-	}
-	return b.newClient(token), nil
 }
 
 const backendHelp = `

--- a/backend.go
+++ b/backend.go
@@ -3,6 +3,7 @@ package cloudflaresecrets
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -22,6 +23,26 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 // API tokens.
 type cloudflareBackend struct {
 	*framework.Backend
+	// lock serializes read-modify-write mutations of the config and role
+	// entries. Vault core does not serialize concurrent logical requests to the
+	// same storage key across a Get+Put, so without this two concurrent writes
+	// could lose an update (e.g. a rotated parent token clobbered back).
+	lock sync.RWMutex
+	// apiBaseURL, when non-empty, overrides the Cloudflare API base URL for
+	// every client this backend builds. It is a test-only seam: it is not
+	// settable through any configured path, so it cannot be influenced by an
+	// operator or attacker.
+	apiBaseURL string
+}
+
+// newClient builds a Cloudflare client for a parent token, applying the
+// backend's API base override when set (tests only).
+func (b *cloudflareBackend) newClient(token string) *cloudflareClient {
+	c := newCloudflareClient(token)
+	if b.apiBaseURL != "" {
+		c.baseURL = b.apiBaseURL
+	}
+	return c
 }
 
 func newBackend() *cloudflareBackend {
@@ -34,6 +55,7 @@ func newBackend() *cloudflareBackend {
 			pathRole(b),
 			[]*framework.Path{
 				pathConfig(b),
+				pathConfigRotateRoot(b),
 				pathCreds(b),
 			},
 		),
@@ -64,7 +86,7 @@ func (b *cloudflareBackend) clientForTokenType(ctx context.Context, s logical.St
 	if err != nil {
 		return nil, err
 	}
-	return newCloudflareClient(token), nil
+	return b.newClient(token), nil
 }
 
 const backendHelp = `

--- a/client.go
+++ b/client.go
@@ -8,11 +8,28 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 )
 
 // cloudflareAPIBase is the root of the Cloudflare v4 REST API.
 const cloudflareAPIBase = "https://api.cloudflare.com/client/v4"
+
+const (
+	// maxResponseBytes bounds how much of a Cloudflare response body is read
+	// into memory, protecting the Vault process from a malicious or
+	// malfunctioning endpoint returning an unbounded body. Token responses are
+	// a few KB at most.
+	maxResponseBytes = 2 << 20 // 2 MiB
+
+	// maxRetries is the number of additional attempts made after the first for
+	// transiently-failing requests (429 / 5xx / transport errors).
+	maxRetries = 3
+
+	// defaultRetryBackoff is the initial wait before the first retry; it
+	// doubles each subsequent attempt unless the server sends Retry-After.
+	defaultRetryBackoff = 250 * time.Millisecond
+)
 
 // Token contexts. Cloudflare mints either account-owned tokens (tied to a
 // service, created under /accounts/{id}/tokens) or user-owned tokens (tied to
@@ -48,14 +65,68 @@ func (s tokenScope) basePath() (string, error) {
 // with a parent API token allowed to mint and delete other tokens.
 type cloudflareClient struct {
 	apiToken   string
+	baseURL    string
 	httpClient *http.Client
+	// retryBackoff is the initial backoff before the first retry. Zero means
+	// defaultRetryBackoff; tests set it small to stay fast.
+	retryBackoff time.Duration
 }
 
 func newCloudflareClient(apiToken string) *cloudflareClient {
 	return &cloudflareClient{
-		apiToken:   apiToken,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		apiToken:     apiToken,
+		baseURL:      cloudflareAPIBase,
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		retryBackoff: defaultRetryBackoff,
 	}
+}
+
+// cfError is a Cloudflare API error carrying the HTTP status and the first
+// Cloudflare error code/message, so callers can react to specific conditions
+// (for example, treating a 404 on delete as already-gone).
+type cfError struct {
+	StatusCode int
+	Code       int
+	Message    string
+}
+
+func (e *cfError) Error() string {
+	if e.Code != 0 || e.Message != "" {
+		return fmt.Sprintf("cloudflare API error (status %d): code %d: %s", e.StatusCode, e.Code, e.Message)
+	}
+	return fmt.Sprintf("cloudflare API request failed with status %d", e.StatusCode)
+}
+
+// isNotFound reports whether the error signals that the target resource no
+// longer exists (HTTP 404), so an operation such as delete can be treated as
+// already complete.
+func (e *cfError) isNotFound() bool {
+	return e.StatusCode == http.StatusNotFound
+}
+
+// idempotent reports whether a request method is safe to retry after a
+// transient failure without risking a duplicate side effect. POST is excluded
+// because a lost response could hide a token that was actually created.
+func idempotent(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodDelete, http.MethodPut, http.MethodHead:
+		return true
+	default:
+		return false
+	}
+}
+
+// retryAfterHeader parses a Retry-After header expressed as a number of
+// seconds. It ignores the HTTP-date form and any unparseable value.
+func retryAfterHeader(resp *http.Response) time.Duration {
+	v := resp.Header.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return 0
 }
 
 // cfAPIError mirrors a single entry of the Cloudflare "errors" array.
@@ -115,54 +186,111 @@ type tokenResult struct {
 	Value string `json:"value"`
 }
 
-// do performs an authenticated request and unwraps the response envelope.
+// do performs an authenticated request and unwraps the response envelope,
+// retrying transient failures (429 / 5xx / transport errors) with backoff.
+// Non-idempotent methods (POST) are not retried on ambiguous failures so a
+// lost response cannot cause a duplicate token to be minted.
 func (c *cloudflareClient) do(ctx context.Context, method, path string, body, out interface{}) error {
-	var reqBody io.Reader
+	var bodyBytes []byte
 	if body != nil {
 		b, err := json.Marshal(body)
 		if err != nil {
 			return err
 		}
-		reqBody = bytes.NewReader(b)
+		bodyBytes = b
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, cloudflareAPIBase+path, reqBody)
+	base := c.baseURL
+	if base == "" {
+		base = cloudflareAPIBase
+	}
+	url := base + path
+
+	backoff := c.retryBackoff
+	if backoff <= 0 {
+		backoff = defaultRetryBackoff
+	}
+
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		status, retryAfter, err := c.doOnce(ctx, method, url, bodyBytes, out)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		// status == 0 indicates a transport error (no HTTP response).
+		transient := status == 0 || status == http.StatusTooManyRequests || status >= 500
+		allowRetry := status == http.StatusTooManyRequests || idempotent(method)
+		if !transient || !allowRetry || attempt >= maxRetries {
+			return lastErr
+		}
+
+		wait := backoff
+		if retryAfter > 0 {
+			wait = retryAfter
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+		backoff *= 2
+	}
+}
+
+// doOnce performs a single HTTP attempt. It returns the HTTP status code (0 on
+// a transport error), the server's Retry-After hint if any, and the error (nil
+// on success). On success it unmarshals the result into out.
+func (c *cloudflareClient) doOnce(ctx context.Context, method, url string, bodyBytes []byte, out interface{}) (int, time.Duration, error) {
+	var reqBody io.Reader
+	if bodyBytes != nil {
+		reqBody = bytes.NewReader(bodyBytes)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
-		return err
+		return 0, 0, err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.apiToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return err
+		return 0, 0, err
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	// Bound the read: token responses are tiny, and an unbounded body from a
+	// misbehaving endpoint must not exhaust Vault's memory.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
-		return err
+		return resp.StatusCode, retryAfterHeader(resp), err
 	}
 
 	var cfResp cfResponse
 	if err := json.Unmarshal(data, &cfResp); err != nil {
-		return fmt.Errorf("cloudflare: failed to parse response (status %d): %s", resp.StatusCode, string(data))
+		// The body is not the expected envelope. Do NOT echo it: token-endpoint
+		// responses can contain a freshly minted secret token value.
+		return resp.StatusCode, retryAfterHeader(resp),
+			fmt.Errorf("cloudflare: failed to parse response (status %d)", resp.StatusCode)
 	}
 
 	if !cfResp.Success {
+		apiErr := &cfError{StatusCode: resp.StatusCode}
 		if len(cfResp.Errors) > 0 {
-			return fmt.Errorf("cloudflare API error (status %d): code %d: %s",
-				resp.StatusCode, cfResp.Errors[0].Code, cfResp.Errors[0].Message)
+			apiErr.Code = cfResp.Errors[0].Code
+			apiErr.Message = cfResp.Errors[0].Message
 		}
-		return fmt.Errorf("cloudflare API request failed with status %d", resp.StatusCode)
+		return resp.StatusCode, retryAfterHeader(resp), apiErr
 	}
 
 	if out != nil && len(cfResp.Result) > 0 {
 		if err := json.Unmarshal(cfResp.Result, out); err != nil {
-			return err
+			return resp.StatusCode, 0, err
 		}
 	}
-	return nil
+	return resp.StatusCode, 0, nil
 }
 
 // listPermissionGroups returns the permission groups available in a scope.

--- a/client.go
+++ b/client.go
@@ -288,6 +288,13 @@ func (c *cloudflareClient) doOnce(ctx context.Context, method, url string, bodyB
 		return resp.StatusCode, retryAfterHeader(resp), apiErr
 	}
 
+	// Guard against a non-2xx response that nonetheless claims success (e.g. a
+	// misbehaving proxy/cache): the HTTP layer's own signal must agree.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, retryAfterHeader(resp),
+			&cfError{StatusCode: resp.StatusCode, Message: "success=true on a non-2xx response"}
+	}
+
 	if out != nil && len(cfResp.Result) > 0 {
 		if err := json.Unmarshal(cfResp.Result, out); err != nil {
 			return resp.StatusCode, 0, err

--- a/client.go
+++ b/client.go
@@ -322,6 +322,39 @@ func (c *cloudflareClient) createToken(ctx context.Context, scope tokenScope, re
 	return &res, nil
 }
 
+// verifyToken returns the ID of the token used to authenticate this client, by
+// calling the scope's tokens/verify endpoint. It is used by root rotation to
+// discover the parent token's own ID before rolling it.
+func (c *cloudflareClient) verifyToken(ctx context.Context, scope tokenScope) (string, error) {
+	base, err := scope.basePath()
+	if err != nil {
+		return "", err
+	}
+	var res struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := c.do(ctx, http.MethodGet, base+"/tokens/verify", nil, &res); err != nil {
+		return "", err
+	}
+	return res.ID, nil
+}
+
+// rollToken regenerates the value of tokenID and returns the new value. The
+// token's ID and permissions are preserved; only the secret changes. The old
+// value is invalidated by Cloudflare once this returns.
+func (c *cloudflareClient) rollToken(ctx context.Context, scope tokenScope, tokenID string) (string, error) {
+	base, err := scope.basePath()
+	if err != nil {
+		return "", err
+	}
+	var newValue string
+	if err := c.do(ctx, http.MethodPut, base+"/tokens/"+url.PathEscape(tokenID)+"/value", struct{}{}, &newValue); err != nil {
+		return "", err
+	}
+	return newValue, nil
+}
+
 // deleteToken revokes a previously created token by ID in the given scope.
 //
 // Revocation is idempotent: if the token is already gone (expired via the

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -55,7 +56,9 @@ func (s tokenScope) basePath() (string, error) {
 		if s.AccountID == "" {
 			return "", errors.New("account_id is required for account-owned tokens")
 		}
-		return "/accounts/" + s.AccountID, nil
+		// Escape as defense-in-depth even though account_id is validated on
+		// write, so a stored value can never manipulate the request path.
+		return "/accounts/" + url.PathEscape(s.AccountID), nil
 	default:
 		return "", fmt.Errorf("invalid token_type %q (must be %q or %q)", s.Type, tokenTypeAccount, tokenTypeUser)
 	}
@@ -331,7 +334,7 @@ func (c *cloudflareClient) deleteToken(ctx context.Context, scope tokenScope, to
 	if err != nil {
 		return err
 	}
-	err = c.do(ctx, http.MethodDelete, base+"/tokens/"+tokenID, nil, nil)
+	err = c.do(ctx, http.MethodDelete, base+"/tokens/"+url.PathEscape(tokenID), nil, nil)
 
 	var apiErr *cfError
 	if errors.As(err, &apiErr) && apiErr.isNotFound() {

--- a/client.go
+++ b/client.go
@@ -320,10 +320,22 @@ func (c *cloudflareClient) createToken(ctx context.Context, scope tokenScope, re
 }
 
 // deleteToken revokes a previously created token by ID in the given scope.
+//
+// Revocation is idempotent: if the token is already gone (expired via the
+// Cloudflare-side expires_on backstop, deleted out-of-band, or a double
+// revoke), Cloudflare returns 404. That is treated as success so Vault can
+// clear the lease, instead of the revocation failing forever and wedging the
+// lease in Vault's retry queue.
 func (c *cloudflareClient) deleteToken(ctx context.Context, scope tokenScope, tokenID string) error {
 	base, err := scope.basePath()
 	if err != nil {
 		return err
 	}
-	return c.do(ctx, http.MethodDelete, base+"/tokens/"+tokenID, nil, nil)
+	err = c.do(ctx, http.MethodDelete, base+"/tokens/"+tokenID, nil, nil)
+
+	var apiErr *cfError
+	if errors.As(err, &apiErr) && apiErr.isNotFound() {
+		return nil
+	}
+	return err
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,144 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestClient returns a client whose requests are directed at srv instead of
+// the real Cloudflare API, with a tiny retry backoff so tests stay fast.
+func newTestClient(srv *httptest.Server) *cloudflareClient {
+	c := newCloudflareClient("test-parent-token")
+	c.baseURL = srv.URL
+	c.retryBackoff = time.Millisecond
+	return c
+}
+
+func writeEnvelope(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}
+
+// TestDoRetriesOn429ThenSucceeds verifies transient 429s are retried and the
+// Retry-After header is honored for pacing.
+func TestDoRetriesOn429ThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			writeEnvelope(w, http.StatusTooManyRequests,
+				`{"success":false,"errors":[{"code":10000,"message":"rate limited"}]}`)
+			return
+		}
+		writeEnvelope(w, http.StatusOK, `{"success":true,"result":{"ok":true}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.do(context.Background(), http.MethodGet, "/x", nil, nil); err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected 2 attempts (429 then 200), got %d", got)
+	}
+}
+
+// TestDoDoesNotRetryPostOn500 verifies that an ambiguous 5xx on a POST is not
+// retried, so a lost response cannot mint duplicate tokens.
+func TestDoDoesNotRetryPostOn500(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		writeEnvelope(w, http.StatusInternalServerError,
+			`{"success":false,"errors":[{"code":10000,"message":"boom"}]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	err := c.do(context.Background(), http.MethodPost, "/x", map[string]string{"a": "b"}, nil)
+	if err == nil {
+		t.Fatal("expected error from 500")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("POST must not be retried on 5xx; expected 1 attempt, got %d", got)
+	}
+}
+
+// TestDoRetriesIdempotent5xxThenGivesUp verifies a GET is retried on 5xx up to
+// the cap and then returns the error.
+func TestDoRetriesIdempotent5xxThenGivesUp(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		writeEnvelope(w, http.StatusBadGateway, `{"success":false,"errors":[{"code":10000,"message":"bad gateway"}]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.do(context.Background(), http.MethodGet, "/x", nil, nil); err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if got := atomic.LoadInt32(&calls); got != maxRetries+1 {
+		t.Fatalf("expected %d attempts, got %d", maxRetries+1, got)
+	}
+}
+
+// TestDoParseErrorDoesNotLeakBody verifies that when the response is not a
+// valid envelope, the raw body (which may contain a secret token value) is not
+// included in the returned error.
+func TestDoParseErrorDoesNotLeakBody(t *testing.T) {
+	const secret = "v1.0-SUPERSECRETTOKENVALUE-should-not-appear"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 200 OK but not the expected JSON envelope, carrying a secret.
+		writeEnvelope(w, http.StatusOK, `<html>token=`+secret+`</html>`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	err := c.do(context.Background(), http.MethodGet, "/x", nil, nil)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked response body containing a secret: %v", err)
+	}
+}
+
+// TestDoBoundsResponseBody verifies an oversized body is truncated by the read
+// limit (the truncated, invalid JSON then fails to parse) rather than being
+// read unbounded into memory.
+func TestDoBoundsResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Valid JSON prefix followed by far more than maxResponseBytes of junk.
+		_, _ = w.Write([]byte(`{"success":true,"result":`))
+		junk := strings.Repeat("A", maxResponseBytes+1024)
+		_, _ = w.Write([]byte(junk))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	// Truncated at the limit, so it is not valid JSON -> parse error, and
+	// crucially the process did not read the whole oversized body.
+	if err := c.do(context.Background(), http.MethodGet, "/x", nil, nil); err == nil {
+		t.Fatal("expected parse error on truncated oversized body")
+	}
+}
+
+// TestCfErrorIsNotFound verifies the 404 classification used by idempotent
+// revocation.
+func TestCfErrorIsNotFound(t *testing.T) {
+	if !(&cfError{StatusCode: http.StatusNotFound}).isNotFound() {
+		t.Fatal("404 cfError should be classified as not-found")
+	}
+	if (&cfError{StatusCode: http.StatusForbidden}).isNotFound() {
+		t.Fatal("403 cfError must not be classified as not-found")
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -162,6 +162,20 @@ func TestDeleteTokenIdempotentOn404(t *testing.T) {
 	}
 }
 
+// TestDoRejectsSuccessOnNon2xx verifies a non-2xx response claiming success is
+// treated as an error rather than trusted. [L2]
+func TestDoRejectsSuccessOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(w, http.StatusNotFound, `{"success":true,"result":{}}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.do(context.Background(), http.MethodGet, "/x", nil, nil); err == nil {
+		t.Fatal("expected error for success=true on a 404")
+	}
+}
+
 // TestDeleteTokenPropagatesRealErrors verifies that a genuine failure (403) is
 // still surfaced, so revocation problems that are not "already gone" are not
 // silently swallowed.

--- a/client_test.go
+++ b/client_test.go
@@ -142,3 +142,39 @@ func TestCfErrorIsNotFound(t *testing.T) {
 		t.Fatal("403 cfError must not be classified as not-found")
 	}
 }
+
+// TestDeleteTokenIdempotentOn404 verifies that deleting an already-gone token
+// returns nil, so Vault can clear the lease instead of retrying forever. [H1]
+func TestDeleteTokenIdempotentOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		writeEnvelope(w, http.StatusNotFound,
+			`{"success":false,"errors":[{"code":1001,"message":"token not found"}],"result":null}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	scope := tokenScope{Type: tokenTypeAccount, AccountID: "acct"}
+	if err := c.deleteToken(context.Background(), scope, "already-gone"); err != nil {
+		t.Fatalf("expected 404 delete to be treated as success, got: %v", err)
+	}
+}
+
+// TestDeleteTokenPropagatesRealErrors verifies that a genuine failure (403) is
+// still surfaced, so revocation problems that are not "already gone" are not
+// silently swallowed.
+func TestDeleteTokenPropagatesRealErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(w, http.StatusForbidden,
+			`{"success":false,"errors":[{"code":9109,"message":"unauthorized"}],"result":null}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	scope := tokenScope{Type: tokenTypeAccount, AccountID: "acct"}
+	if err := c.deleteToken(context.Background(), scope, "tok"); err == nil {
+		t.Fatal("expected a 403 to propagate as an error, got nil")
+	}
+}

--- a/cmd/vault-cloudflare-secret-engine/main.go
+++ b/cmd/vault-cloudflare-secret-engine/main.go
@@ -33,6 +33,9 @@ func main() {
 		logFatal(err)
 	}
 
+	// Report the build version to Vault (vault plugin list / pinning).
+	cloudflaresecrets.PluginVersion = "v" + version
+
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -24,3 +24,19 @@ func newTestBackend(t *testing.T) (logical.Backend, logical.Storage) {
 	}
 	return b, storage
 }
+
+// newTestBackendWithAPI builds a *cloudflareBackend whose Cloudflare clients are
+// pointed at apiBaseURL (an httptest server), so backend flows that call the
+// Cloudflare API can be exercised offline.
+func newTestBackendWithAPI(t *testing.T, apiBaseURL string) (*cloudflareBackend, logical.Storage) {
+	t.Helper()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b := newBackend()
+	b.apiBaseURL = apiBaseURL
+	if err := b.Setup(context.Background(), conf); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	return b, storage
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,26 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// testAccountID is a syntactically valid (32-char lowercase hex) Cloudflare
+// account ID for unit tests that exercise config/role writes now that the
+// account ID format is validated.
+const testAccountID = "0123456789abcdef0123456789abcdef"
+
+// newTestBackend builds a backend backed by in-memory storage for unit tests.
+func newTestBackend(t *testing.T) (logical.Backend, logical.Storage) {
+	t.Helper()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b, err := Factory(context.Background(), conf)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	return b, storage
+}

--- a/path_config.go
+++ b/path_config.go
@@ -20,6 +20,11 @@ var errBackendNotConfigured = errors.New("cloudflare backend not configured; wri
 const (
 	defaultTTL = time.Hour
 	defaultMax = 24 * time.Hour
+
+	// expiryBackstopBuffer is added to a token's max_ttl when setting its
+	// Cloudflare-side expires_on, so the token always outlives the Vault lease's
+	// latest possible end despite lease-commit delay and clock skew.
+	expiryBackstopBuffer = 5 * time.Minute
 )
 
 // cloudflareConfig is the persisted backend configuration. It can hold

--- a/path_config.go
+++ b/path_config.go
@@ -171,6 +171,11 @@ func (b *cloudflareBackend) pathConfigWrite(ctx context.Context, req *logical.Re
 	if (config.AccountID == "") != (config.APIToken == "") {
 		return logical.ErrorResponse("account credentials require both cloudflare_account_id and cloudflare_api_token"), nil
 	}
+	if config.AccountID != "" {
+		if err := validateAccountID(config.AccountID); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+	}
 	// At least one usable context (account and/or user) must be configured.
 	hasAccount := config.AccountID != "" && config.APIToken != ""
 	hasUser := config.UserAPIToken != ""

--- a/path_config.go
+++ b/path_config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -280,6 +279,7 @@ func (b *cloudflareBackend) pathConfigRotateRoot(ctx context.Context, req *logic
 	if err := req.Storage.Put(ctx, entry); err != nil {
 		return nil, err
 	}
+	b.Logger().Info("rotated parent cloudflare token", "token_type", tokenType, "token_id", tokenID)
 
 	return &logical.Response{
 		Data: map[string]interface{}{
@@ -314,10 +314,15 @@ func getConfig(ctx context.Context, s logical.Storage) (*cloudflareConfig, error
 	return config, nil
 }
 
-// maskToken returns the token with all but the last four characters hidden.
+// redactedToken is the fixed placeholder returned for a configured token. It
+// reveals neither the token's length nor any of its characters.
+const redactedToken = "***redacted***"
+
+// maskToken reports whether a token is configured without disclosing any of its
+// bytes or its length: empty stays empty, anything else becomes a fixed marker.
 func maskToken(token string) string {
-	if len(token) <= 4 {
-		return strings.Repeat("x", len(token))
+	if token == "" {
+		return ""
 	}
-	return strings.Repeat("x", len(token)-4) + token[len(token)-4:]
+	return redactedToken
 }

--- a/path_config.go
+++ b/path_config.go
@@ -130,6 +130,9 @@ func (b *cloudflareBackend) pathConfigRead(ctx context.Context, req *logical.Req
 }
 
 func (b *cloudflareBackend) pathConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	config, err := getConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
@@ -195,7 +198,96 @@ func (b *cloudflareBackend) pathConfigWrite(ctx context.Context, req *logical.Re
 }
 
 func (b *cloudflareBackend) pathConfigDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return nil, req.Storage.Delete(ctx, configStoragePath)
+}
+
+func pathConfigRotateRoot(b *cloudflareBackend) *framework.Path {
+	return &framework.Path{
+		Pattern: "config/rotate-root",
+		Fields: map[string]*framework.FieldSchema{
+			"token_type": {
+				Type:        framework.TypeString,
+				Description: `Which parent credential to rotate: "account" (default) or "user".`,
+				Default:     tokenTypeAccount,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathConfigRotateRoot},
+		},
+		HelpSynopsis: "Rotate a parent Cloudflare API token in place.",
+		HelpDescription: `Rolls the configured parent token's value via the Cloudflare API and
+stores the new value, so the bootstrap credential is owned and rotatable by
+Vault. The token's ID and permissions are preserved; only the secret changes.
+The plaintext value is never returned.`,
+	}
+}
+
+// pathConfigRotateRoot rolls a configured parent token's value and persists it.
+// It discovers the token's own ID via the verify endpoint, rolls the value, and
+// writes the new value back to config. The old value is invalidated by
+// Cloudflare, so the bootstrap credential becomes Vault-owned.
+func (b *cloudflareBackend) pathConfigRotateRoot(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	tokenType := d.Get("token_type").(string)
+	if tokenType != tokenTypeAccount && tokenType != tokenTypeUser {
+		return logical.ErrorResponse("token_type must be %q or %q", tokenTypeAccount, tokenTypeUser), nil
+	}
+
+	config, err := getConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, errBackendNotConfigured
+	}
+
+	token, err := config.parentTokenFor(tokenType)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	scope := tokenScope{Type: tokenType, AccountID: config.AccountID}
+	client := b.newClient(token)
+
+	tokenID, err := client.verifyToken(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("verifying parent token before rotation: %w", err)
+	}
+	newValue, err := client.rollToken(ctx, scope, tokenID)
+	if err != nil {
+		return nil, fmt.Errorf("rolling parent token: %w", err)
+	}
+	if newValue == "" {
+		return nil, fmt.Errorf("cloudflare returned an empty value when rolling the parent token")
+	}
+
+	switch tokenType {
+	case tokenTypeUser:
+		config.UserAPIToken = newValue
+	default:
+		config.APIToken = newValue
+	}
+
+	entry, err := logical.StorageEntryJSON(configStoragePath, config)
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(ctx, entry); err != nil {
+		return nil, err
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"token_type": tokenType,
+			"token_id":   tokenID,
+			"rotated":    true,
+		},
+	}, nil
 }
 
 func getConfig(ctx context.Context, s logical.Storage) (*cloudflareConfig, error) {

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -38,10 +38,11 @@ func TestConfigWriteValidation(t *testing.T) {
 		data    map[string]interface{}
 		wantErr bool
 	}{
-		{"account only", map[string]interface{}{"cloudflare_account_id": "a", "cloudflare_api_token": "t"}, false},
+		{"account only", map[string]interface{}{"cloudflare_account_id": testAccountID, "cloudflare_api_token": "t"}, false},
 		{"user only", map[string]interface{}{"cloudflare_user_api_token": "u"}, false},
-		{"both", map[string]interface{}{"cloudflare_account_id": "a", "cloudflare_api_token": "t", "cloudflare_user_api_token": "u"}, false},
-		{"account_id without token", map[string]interface{}{"cloudflare_account_id": "a"}, true},
+		{"both", map[string]interface{}{"cloudflare_account_id": testAccountID, "cloudflare_api_token": "t", "cloudflare_user_api_token": "u"}, false},
+		{"account_id without token", map[string]interface{}{"cloudflare_account_id": testAccountID}, true},
+		{"malformed account_id", map[string]interface{}{"cloudflare_account_id": "not-hex", "cloudflare_api_token": "t"}, true},
 		{"token without account_id", map[string]interface{}{"cloudflare_api_token": "t"}, true},
 		{"nothing", map[string]interface{}{}, true},
 	}
@@ -86,7 +87,7 @@ func TestConfigReadMasksBothTokens(t *testing.T) {
 		Path:      "config",
 		Storage:   storage,
 		Data: map[string]interface{}{
-			"cloudflare_account_id":     "acct",
+			"cloudflare_account_id":     testAccountID,
 			"cloudflare_api_token":      "secret-account-token",
 			"cloudflare_user_api_token": "secret-user-token",
 		},

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -108,8 +108,9 @@ func TestConfigReadMasksBothTokens(t *testing.T) {
 		if strings.Contains(v, "secret-") {
 			t.Fatalf("%s leaked unmasked: %q", field, v)
 		}
-		if !strings.HasPrefix(v, "x") {
-			t.Fatalf("%s not masked: %q", field, v)
+		// The mask must reveal neither content nor length: a fixed marker.
+		if v != redactedToken {
+			t.Fatalf("%s not fully masked: %q", field, v)
 		}
 	}
 }

--- a/path_creds.go
+++ b/path_creds.go
@@ -82,7 +82,7 @@ func (b *cloudflareBackend) pathCredsRead(ctx context.Context, req *logical.Requ
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
-	client := newCloudflareClient(parentToken)
+	client := b.newClient(parentToken)
 
 	// Parse the role's stored policies and resolve permission group names → IDs.
 	// The live permission group catalog is only fetched when a policy actually

--- a/path_creds.go
+++ b/path_creds.go
@@ -124,6 +124,10 @@ func (b *cloudflareBackend) pathCredsRead(ctx context.Context, req *logical.Requ
 	if err != nil {
 		return nil, fmt.Errorf("error creating cloudflare token: %w", err)
 	}
+	if token.ID == "" {
+		return nil, fmt.Errorf("cloudflare returned a token with no ID; refusing to issue an unrevocable credential")
+	}
+	b.Logger().Info("minted cloudflare token", "role", roleName, "token_id", token.ID, "token_type", scope.Type)
 
 	resp := b.Secret(cloudflareTokenType).Response(
 		map[string]interface{}{
@@ -166,21 +170,36 @@ func policiesNeedNameResolution(policies []policy) bool {
 // resolvePermissionGroups rewrites each policy's permission groups so they carry
 // a concrete Cloudflare ID, resolving any name-only references against the live
 // permission group list. The Name field is cleared so the request sends IDs.
+//
+// Cloudflare's catalog can contain multiple groups that share a display name
+// (across scopes/products). A name that maps to more than one distinct ID is
+// rejected as ambiguous rather than silently resolved to whichever entry
+// happened to be last, which could grant a broader group than intended.
 func resolvePermissionGroups(policies []policy, all []permissionGroup) error {
-	byName := make(map[string]string, len(all))
+	byName := make(map[string]map[string]struct{}, len(all))
 	for _, pg := range all {
-		byName[strings.ToLower(pg.Name)] = pg.ID
+		key := strings.ToLower(pg.Name)
+		if byName[key] == nil {
+			byName[key] = make(map[string]struct{})
+		}
+		byName[key][pg.ID] = struct{}{}
 	}
 
 	for i := range policies {
 		for j := range policies[i].PermissionGroups {
 			pg := &policies[i].PermissionGroups[j]
 			if pg.ID == "" {
-				id, ok := byName[strings.ToLower(pg.Name)]
-				if !ok {
+				ids := byName[strings.ToLower(pg.Name)]
+				switch len(ids) {
+				case 0:
 					return fmt.Errorf("unknown cloudflare permission group name %q", pg.Name)
+				case 1:
+					for id := range ids {
+						pg.ID = id
+					}
+				default:
+					return fmt.Errorf("cloudflare permission group name %q is ambiguous: %d groups share it; reference it by id instead", pg.Name, len(ids))
 				}
-				pg.ID = id
 			}
 			pg.Name = ""
 		}

--- a/path_creds.go
+++ b/path_creds.go
@@ -151,6 +151,21 @@ func (b *cloudflareBackend) pathCredsRead(ctx context.Context, req *logical.Requ
 	resp.Secret.TTL = ttl
 	resp.Secret.MaxTTL = maxTTL
 
+	// Optionally surface a derived R2 S3 keypair. The Access Key ID is the
+	// token ID and the Secret Access Key is the hex SHA-256 of the token value;
+	// both are invalidated when the lease is revoked (the token is deleted).
+	if role.R2S3Credentials {
+		resp.Data["r2_access_key_id"] = token.ID
+		resp.Data["r2_secret_access_key"] = r2SecretAccessKey(token.Value)
+		r2AccountID := scope.AccountID
+		if r2AccountID == "" {
+			r2AccountID = config.AccountID
+		}
+		if r2AccountID != "" {
+			resp.Data["r2_endpoint"] = r2Endpoint(r2AccountID)
+		}
+	}
+
 	return resp, nil
 }
 

--- a/path_creds.go
+++ b/path_creds.go
@@ -102,11 +102,16 @@ func (b *cloudflareBackend) pathCredsRead(ctx context.Context, req *logical.Requ
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	// Cloudflare-side expiry backstop in case Vault never revokes.
+	// Cloudflare-side expiry backstop in case Vault never revokes. A buffer is
+	// added on top of max_ttl so the Cloudflare token always outlives the Vault
+	// lease's latest possible end (the lease is committed slightly after this
+	// call, and clocks may skew); otherwise a lease renewed to its cap could
+	// briefly wrap an already-expired token.
 	backstop := maxTTL
 	if backstop <= 0 {
 		backstop = defaultMax
 	}
+	backstop += expiryBackstopBuffer
 
 	tokenReq := &createTokenRequest{
 		Name:      fmt.Sprintf("vault-%s-%d", roleName, time.Now().Unix()),

--- a/path_roles.go
+++ b/path_roles.go
@@ -15,13 +15,14 @@ import (
 // Cloudflare token context (account vs user) and the full policy set (ACL +
 // resources) that every generated token receives.
 type cloudflareRoleEntry struct {
-	TokenType      string          `json:"token_type"`
-	AccountID      string          `json:"account_id,omitempty"`
-	Policies       json.RawMessage `json:"policies"`
-	RequestIPIn    []string        `json:"request_ip_in,omitempty"`
-	RequestIPNotIn []string        `json:"request_ip_not_in,omitempty"`
-	TTL            time.Duration   `json:"ttl"`
-	MaxTTL         time.Duration   `json:"max_ttl"`
+	TokenType       string          `json:"token_type"`
+	AccountID       string          `json:"account_id,omitempty"`
+	Policies        json.RawMessage `json:"policies"`
+	RequestIPIn     []string        `json:"request_ip_in,omitempty"`
+	RequestIPNotIn  []string        `json:"request_ip_not_in,omitempty"`
+	R2S3Credentials bool            `json:"r2_s3_credentials,omitempty"`
+	TTL             time.Duration   `json:"ttl"`
+	MaxTTL          time.Duration   `json:"max_ttl"`
 }
 
 func (r *cloudflareRoleEntry) toResponseData() map[string]interface{} {
@@ -31,6 +32,7 @@ func (r *cloudflareRoleEntry) toResponseData() map[string]interface{} {
 		"policies":          json.RawMessage(r.Policies),
 		"request_ip_in":     r.RequestIPIn,
 		"request_ip_not_in": r.RequestIPNotIn,
+		"r2_s3_credentials": r.R2S3Credentials,
 		"ttl":               int64(r.TTL.Seconds()),
 		"max_ttl":           int64(r.MaxTTL.Seconds()),
 	}
@@ -67,6 +69,10 @@ func pathRole(b *cloudflareBackend) []*framework.Path {
 				"request_ip_not_in": {
 					Type:        framework.TypeCommaStringSlice,
 					Description: "Optional client-IP deny list (IPv4/IPv6 CIDRs). The token is rejected from these addresses.",
+				},
+				"r2_s3_credentials": {
+					Type:        framework.TypeBool,
+					Description: "If true, creds responses also include a derived R2 S3 keypair (r2_access_key_id, r2_secret_access_key) and r2_endpoint for use against R2's S3-compatible API. The role's policies must grant R2 permissions.",
 				},
 				"ttl": {
 					Type:        framework.TypeDurationSecond,
@@ -187,6 +193,10 @@ func (b *cloudflareBackend) pathRolesWrite(ctx context.Context, req *logical.Req
 	}
 	if err := validateIPRestrictions("request_ip_not_in", role.RequestIPNotIn); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	if v, ok := d.GetOk("r2_s3_credentials"); ok {
+		role.R2S3Credentials = v.(bool)
 	}
 
 	if v, ok := d.GetOk("ttl"); ok {

--- a/path_roles.go
+++ b/path_roles.go
@@ -152,6 +152,11 @@ func (b *cloudflareBackend) pathRolesWrite(ctx context.Context, req *logical.Req
 	if v, ok := d.GetOk("account_id"); ok {
 		role.AccountID = v.(string)
 	}
+	if role.AccountID != "" {
+		if err := validateAccountID(role.AccountID); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+	}
 
 	if v, ok := d.GetOk("policies"); ok {
 		policies, err := parsePolicies(v.(string))
@@ -173,6 +178,12 @@ func (b *cloudflareBackend) pathRolesWrite(ctx context.Context, req *logical.Req
 	}
 	if v, ok := d.GetOk("request_ip_not_in"); ok {
 		role.RequestIPNotIn = v.([]string)
+	}
+	if err := validateIPRestrictions("request_ip_in", role.RequestIPIn); err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+	if err := validateIPRestrictions("request_ip_not_in", role.RequestIPNotIn); err != nil {
+		return logical.ErrorResponse(err.Error()), nil
 	}
 
 	if v, ok := d.GetOk("ttl"); ok {
@@ -255,8 +266,8 @@ func parsePolicies(raw string) ([]policy, error) {
 				return nil, fmt.Errorf("policy %d: permission_group %d needs an \"id\" or \"name\"", i, j)
 			}
 		}
-		if len(p.Resources) == 0 {
-			return nil, fmt.Errorf("policy %d: resources is required", i)
+		if err := validateResources(p.Resources); err != nil {
+			return nil, fmt.Errorf("policy %d: %w", i, err)
 		}
 	}
 	return policies, nil

--- a/path_roles.go
+++ b/path_roles.go
@@ -126,6 +126,9 @@ func (b *cloudflareBackend) pathRolesRead(ctx context.Context, req *logical.Requ
 }
 
 func (b *cloudflareBackend) pathRolesWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	name, ok := d.GetOk("name")
 	if !ok {
 		return logical.ErrorResponse("missing role name"), nil
@@ -207,6 +210,9 @@ func (b *cloudflareBackend) pathRolesWrite(ctx context.Context, req *logical.Req
 }
 
 func (b *cloudflareBackend) pathRolesDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	if err := req.Storage.Delete(ctx, "role/"+d.Get("name").(string)); err != nil {
 		return nil, fmt.Errorf("error deleting cloudflare role: %w", err)
 	}

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -153,10 +153,15 @@ func TestTokenScopeBasePath(t *testing.T) {
 }
 
 func TestMaskToken(t *testing.T) {
-	if got := maskToken("abcdef1234"); got != "xxxxxx1234" {
-		t.Fatalf("expected xxxxxx1234, got %s", got)
+	// A configured token becomes a fixed marker that leaks neither its content
+	// nor its length; an unset token stays empty.
+	if got := maskToken("abcdef1234"); got != redactedToken {
+		t.Fatalf("expected %q, got %q", redactedToken, got)
 	}
-	if got := maskToken("abc"); got != "xxx" {
-		t.Fatalf("expected xxx, got %s", got)
+	if got := maskToken("a-different-length-secret"); got != redactedToken {
+		t.Fatalf("mask must not depend on length: got %q", got)
+	}
+	if got := maskToken(""); got != "" {
+		t.Fatalf("expected empty for unset token, got %q", got)
 	}
 }

--- a/r2.go
+++ b/r2.go
@@ -1,0 +1,22 @@
+package cloudflaresecrets
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// r2SecretAccessKey derives the R2 S3 Secret Access Key from a Cloudflare API
+// token value: the lowercase hex SHA-256 of the token value. The paired Access
+// Key ID is the token's ID. This is Cloudflare's documented scheme for using an
+// API token (with R2 permissions) as S3-compatible R2 credentials, so the
+// derived keypair is revoked exactly when the underlying token's lease is.
+func r2SecretAccessKey(tokenValue string) string {
+	sum := sha256.Sum256([]byte(tokenValue))
+	return hex.EncodeToString(sum[:])
+}
+
+// r2Endpoint returns the account's S3-compatible R2 endpoint.
+func r2Endpoint(accountID string) string {
+	return fmt.Sprintf("https://%s.r2.cloudflarestorage.com", accountID)
+}

--- a/r2_test.go
+++ b/r2_test.go
@@ -1,0 +1,101 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestR2SecretAccessKey is a known-answer test: the secret is the lowercase hex
+// SHA-256 of the token value. SHA-256("abc") is a well-known digest.
+func TestR2SecretAccessKey(t *testing.T) {
+	const wantABC = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	if got := r2SecretAccessKey("abc"); got != wantABC {
+		t.Fatalf("r2SecretAccessKey(abc) = %q, want %q", got, wantABC)
+	}
+	if got := r2Endpoint(testAccountID); got != "https://"+testAccountID+".r2.cloudflarestorage.com" {
+		t.Fatalf("unexpected endpoint: %q", got)
+	}
+}
+
+// TestCredsR2CredentialsOptIn verifies that a role with r2_s3_credentials=true
+// gets the derived keypair and endpoint in its creds response, and a role
+// without it does not. [M11]
+func TestCredsR2CredentialsOptIn(t *testing.T) {
+	const tokID = "cafebabecafebabecafebabecafebabe"
+	const tokValue = "v1.0-the-minted-token-value"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/tokens") {
+			writeEnvelope(w, http.StatusOK,
+				`{"success":true,"result":{"id":"`+tokID+`","value":"`+tokValue+`","name":"vault-r2-1"}}`)
+			return
+		}
+		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		writeEnvelope(w, http.StatusNotFound, `{"success":false,"errors":[{"code":1,"message":"no"}]}`)
+	}))
+	defer srv.Close()
+
+	b, storage := newTestBackendWithAPI(t, srv.URL)
+	ctx := context.Background()
+
+	mustWrite(t, ctx, b, storage, "config", map[string]interface{}{
+		"cloudflare_account_id": testAccountID,
+		"cloudflare_api_token":  "parent",
+	})
+
+	// Permission group referenced by ID so no live-catalog round-trip is needed.
+	policies := `[{"permission_groups":[{"id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}],"resources":{"com.cloudflare.api.account.` + testAccountID + `":"*"}}]`
+
+	mustWrite(t, ctx, b, storage, "role/r2", map[string]interface{}{
+		"token_type":        "account",
+		"policies":          policies,
+		"r2_s3_credentials": true,
+	})
+	mustWrite(t, ctx, b, storage, "role/plain", map[string]interface{}{
+		"token_type": "account",
+		"policies":   policies,
+	})
+
+	// R2 role: keypair + endpoint present and correct.
+	resp := mustCreds(t, ctx, b, storage, "r2")
+	if resp.Data["r2_access_key_id"] != tokID {
+		t.Fatalf("r2_access_key_id = %v, want token id %s", resp.Data["r2_access_key_id"], tokID)
+	}
+	sk, _ := resp.Data["r2_secret_access_key"].(string)
+	if sk != r2SecretAccessKey(tokValue) {
+		t.Fatalf("r2_secret_access_key mismatch")
+	}
+	if !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(sk) {
+		t.Fatalf("r2_secret_access_key is not 64-char hex: %q", sk)
+	}
+	if resp.Data["r2_endpoint"] != r2Endpoint(testAccountID) {
+		t.Fatalf("r2_endpoint = %v", resp.Data["r2_endpoint"])
+	}
+
+	// Non-R2 role: none of the R2 fields present.
+	resp2 := mustCreds(t, ctx, b, storage, "plain")
+	for _, k := range []string{"r2_access_key_id", "r2_secret_access_key", "r2_endpoint"} {
+		if _, ok := resp2.Data[k]; ok {
+			t.Fatalf("non-R2 role unexpectedly returned %q", k)
+		}
+	}
+}
+
+func mustCreds(t *testing.T, ctx context.Context, b logical.Backend, s logical.Storage, role string) *logical.Response {
+	t.Helper()
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "creds/" + role,
+		Storage:   s,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("creds/%s: err=%v resp=%v", role, err, resp)
+	}
+	return resp
+}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -1,0 +1,63 @@
+package cloudflaresecrets
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func policyByName(name string) []policy {
+	return []policy{{
+		Effect:           "allow",
+		Resources:        json.RawMessage(`{"com.cloudflare.api.account.abc":"*"}`),
+		PermissionGroups: []permissionGroup{{Name: name}},
+	}}
+}
+
+// TestResolvePermissionGroupsUnique resolves a name that maps to a single ID.
+func TestResolvePermissionGroupsUnique(t *testing.T) {
+	catalog := []permissionGroup{
+		{ID: "id-dns", Name: "DNS Write"},
+		{ID: "id-zone", Name: "Zone Read"},
+	}
+	p := policyByName("DNS Write")
+	if err := resolvePermissionGroups(p, catalog); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p[0].PermissionGroups[0].ID != "id-dns" || p[0].PermissionGroups[0].Name != "" {
+		t.Fatalf("unexpected resolution: %#v", p[0].PermissionGroups[0])
+	}
+}
+
+// TestResolvePermissionGroupsAmbiguous rejects a name shared by multiple
+// distinct IDs instead of silently picking one. [H4]
+func TestResolvePermissionGroupsAmbiguous(t *testing.T) {
+	catalog := []permissionGroup{
+		{ID: "id-acct-dns", Name: "DNS Write"},
+		{ID: "id-zone-dns", Name: "DNS Write"}, // same display name, different group
+	}
+	err := resolvePermissionGroups(policyByName("DNS Write"), catalog)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguity error, got: %v", err)
+	}
+}
+
+// TestResolvePermissionGroupsDuplicateSameID treats a name repeated with the
+// same ID as unambiguous (Cloudflare can list a group more than once).
+func TestResolvePermissionGroupsDuplicateSameID(t *testing.T) {
+	catalog := []permissionGroup{
+		{ID: "id-dns", Name: "DNS Write"},
+		{ID: "id-dns", Name: "DNS Write"},
+	}
+	if err := resolvePermissionGroups(policyByName("DNS Write"), catalog); err != nil {
+		t.Fatalf("duplicate-with-same-id should resolve, got: %v", err)
+	}
+}
+
+// TestResolvePermissionGroupsUnknown errors on a name not present in the catalog.
+func TestResolvePermissionGroupsUnknown(t *testing.T) {
+	err := resolvePermissionGroups(policyByName("No Such Group"), []permissionGroup{{ID: "x", Name: "DNS Write"}})
+	if err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("expected unknown-name error, got: %v", err)
+	}
+}

--- a/revoke_test.go
+++ b/revoke_test.go
@@ -1,0 +1,67 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestRevokeGracefulWhenConfigDeleted verifies that if the backend config is
+// removed while a lease is outstanding, revocation clears the lease (returns no
+// error) instead of failing forever; the Cloudflare token is reclaimed by its
+// expires_on backstop. [M4/M5]
+func TestRevokeGracefulWhenConfigDeleted(t *testing.T) {
+	var deleteCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/tokens"):
+			writeEnvelope(w, http.StatusOK, `{"success":true,"result":{"id":"tok","value":"val","name":"n"}}`)
+		case r.Method == http.MethodDelete:
+			deleteCalled = true
+			writeEnvelope(w, http.StatusOK, `{"success":true,"result":{"id":"tok"}}`)
+		default:
+			writeEnvelope(w, http.StatusNotFound, `{"success":false,"errors":[{"code":1,"message":"no"}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	b, storage := newTestBackendWithAPI(t, srv.URL)
+	ctx := context.Background()
+
+	mustWrite(t, ctx, b, storage, "config", map[string]interface{}{
+		"cloudflare_account_id": testAccountID,
+		"cloudflare_api_token":  "parent",
+	})
+	mustWrite(t, ctx, b, storage, "role/r", map[string]interface{}{
+		"token_type": "account",
+		"policies":   `[{"permission_groups":[{"id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}],"resources":{"com.cloudflare.api.account.` + testAccountID + `":"*"}}]`,
+	})
+	minted := mustCreds(t, ctx, b, storage, "r")
+
+	// Remove the config, then revoke the outstanding lease.
+	if _, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.DeleteOperation, Path: "config", Storage: storage,
+	}); err != nil {
+		t.Fatalf("delete config: %v", err)
+	}
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.RevokeOperation,
+		Path:      "creds/r",
+		Storage:   storage,
+		Secret:    minted.Secret,
+	})
+	if err != nil {
+		t.Fatalf("revoke should degrade gracefully, got error: %v", err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatalf("revoke should degrade gracefully, got error response: %v", resp)
+	}
+	if deleteCalled {
+		t.Fatal("delete should not be attempted once the backend is deconfigured")
+	}
+}

--- a/rotate_root_test.go
+++ b/rotate_root_test.go
@@ -1,0 +1,123 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestRotateRootAccount verifies config/rotate-root discovers the parent
+// token's ID via verify, rolls its value, persists the new value, and never
+// returns the plaintext. [H5]
+func TestRotateRootAccount(t *testing.T) {
+	const (
+		oldValue = "v1.0-OLD-PARENT-VALUE"
+		newValue = "v1.0-NEW-ROLLED-VALUE"
+		tokID    = "abcdef0123456789abcdef0123456789"
+	)
+	var verifyCalls, rollCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tokens/verify"):
+			atomic.AddInt32(&verifyCalls, 1)
+			// The verify call must authenticate with the current parent token.
+			if got := r.Header.Get("Authorization"); got != "Bearer "+oldValue {
+				t.Errorf("verify used %q, want bearer old value", got)
+			}
+			writeEnvelope(w, http.StatusOK,
+				`{"success":true,"result":{"id":"`+tokID+`","status":"active"}}`)
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/tokens/"+tokID+"/value"):
+			atomic.AddInt32(&rollCalls, 1)
+			writeEnvelope(w, http.StatusOK, `{"success":true,"result":"`+newValue+`"}`)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			writeEnvelope(w, http.StatusNotFound, `{"success":false,"errors":[{"code":1,"message":"no"}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	b, storage := newTestBackendWithAPI(t, srv.URL)
+	ctx := context.Background()
+
+	if _, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "config",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"cloudflare_account_id": testAccountID,
+			"cloudflare_api_token":  oldValue,
+		},
+	}); err != nil {
+		t.Fatalf("config write: %v", err)
+	}
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/rotate-root",
+		Storage:   storage,
+		Data:      map[string]interface{}{"token_type": tokenTypeAccount},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("rotate-root: err=%v resp=%v", err, resp)
+	}
+	if resp.Data["token_id"] != tokID || resp.Data["rotated"] != true {
+		t.Fatalf("unexpected response data: %#v", resp.Data)
+	}
+	// The plaintext new value must never be returned.
+	for k, v := range resp.Data {
+		if s, ok := v.(string); ok && strings.Contains(s, newValue) {
+			t.Fatalf("response field %q leaked the new token value", k)
+		}
+	}
+	if atomic.LoadInt32(&verifyCalls) != 1 || atomic.LoadInt32(&rollCalls) != 1 {
+		t.Fatalf("expected 1 verify + 1 roll, got %d verify %d roll", verifyCalls, rollCalls)
+	}
+
+	// The rolled value must be persisted so future operations use it.
+	cfg, err := getConfig(ctx, storage)
+	if err != nil {
+		t.Fatalf("getConfig: %v", err)
+	}
+	if cfg.APIToken != newValue {
+		t.Fatalf("config still holds the old token value after rotation")
+	}
+}
+
+// TestRotateRootUnconfiguredContext rejects rotating a context that has no
+// configured credential.
+func TestRotateRootUnconfiguredContext(t *testing.T) {
+	b, storage := newTestBackendWithAPI(t, "http://127.0.0.1:0")
+	ctx := context.Background()
+
+	// Configure only the account context.
+	if _, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "config",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"cloudflare_account_id": testAccountID,
+			"cloudflare_api_token":  "v",
+		},
+	}); err != nil {
+		t.Fatalf("config write: %v", err)
+	}
+
+	resp, err := b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/rotate-root",
+		Storage:   storage,
+		Data:      map[string]interface{}{"token_type": tokenTypeUser},
+	})
+	if err != nil {
+		t.Fatalf("unexpected hard error: %v", err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("expected error rotating an unconfigured user context, got %v", resp)
+	}
+}

--- a/secret_token.go
+++ b/secret_token.go
@@ -2,7 +2,6 @@ package cloudflaresecrets
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -36,7 +35,11 @@ func secretToken(b *cloudflareBackend) *framework.Secret {
 func (b *cloudflareBackend) secretTokenRevoke(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	tokenID, ok := req.Secret.InternalData["token_id"].(string)
 	if !ok || tokenID == "" {
-		return nil, errors.New("secret is missing token_id internal data")
+		// Corrupted or legacy lease with no token ID: there is nothing we can
+		// delete. Clear the lease rather than wedging it; any real token dies at
+		// its Cloudflare-side expires_on backstop.
+		b.Logger().Warn("cloudflare token secret missing token_id; cannot revoke, relying on expiry backstop")
+		return nil, nil
 	}
 
 	scope := tokenScope{}
@@ -47,12 +50,26 @@ func (b *cloudflareBackend) secretTokenRevoke(ctx context.Context, req *logical.
 		scope.AccountID = v
 	}
 
-	client, err := b.clientForTokenType(ctx, req.Storage, scope.Type)
+	// Build the client from current config. If the backend was deconfigured or
+	// the parent credential for this context was removed while leases were
+	// outstanding, we cannot call Cloudflare — clear the lease and let the
+	// expires_on backstop reclaim the token, instead of failing revocation
+	// forever and wedging the lease.
+	config, err := getConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
+	if config == nil {
+		b.Logger().Warn("cloudflare backend not configured at revoke; relying on token expiry backstop", "token_id", tokenID)
+		return nil, nil
+	}
+	token, err := config.parentTokenFor(scope.Type)
+	if err != nil {
+		b.Logger().Warn("parent credential no longer configured; cannot revoke, relying on token expiry backstop", "token_id", tokenID, "token_type", scope.Type)
+		return nil, nil
+	}
 
-	if err := client.deleteToken(ctx, scope, tokenID); err != nil {
+	if err := b.newClient(token).deleteToken(ctx, scope, tokenID); err != nil {
 		return nil, fmt.Errorf("error revoking cloudflare token %s: %w", tokenID, err)
 	}
 	b.Logger().Info("revoked cloudflare token", "token_id", tokenID, "token_type", scope.Type)

--- a/secret_token.go
+++ b/secret_token.go
@@ -55,6 +55,7 @@ func (b *cloudflareBackend) secretTokenRevoke(ctx context.Context, req *logical.
 	if err := client.deleteToken(ctx, scope, tokenID); err != nil {
 		return nil, fmt.Errorf("error revoking cloudflare token %s: %w", tokenID, err)
 	}
+	b.Logger().Info("revoked cloudflare token", "token_id", tokenID, "token_type", scope.Type)
 	return nil, nil
 }
 

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,60 @@
+package cloudflaresecrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"regexp"
+)
+
+// cloudflareIDPattern matches Cloudflare's 32-character lowercase-hex resource
+// identifiers (account IDs, zone IDs, token IDs).
+var cloudflareIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+// validateAccountID rejects anything that is not a Cloudflare account ID. This
+// both catches misconfiguration early and prevents request-path injection: the
+// account ID is interpolated into the Cloudflare API request path, so a value
+// such as "x/../../user" could otherwise retarget the request.
+func validateAccountID(id string) error {
+	if !cloudflareIDPattern.MatchString(id) {
+		return fmt.Errorf("account_id must be a 32-character hex Cloudflare account ID")
+	}
+	return nil
+}
+
+// validateIPRestrictions ensures every entry is a valid IP or IPv4/IPv6 CIDR.
+// Validating at write time means a typo or an empty element (e.g. from a
+// trailing comma) is rejected up front, instead of being silently dropped and
+// weakening a deny list the operator believes is in force.
+func validateIPRestrictions(field string, entries []string) error {
+	for _, e := range entries {
+		if _, _, err := net.ParseCIDR(e); err == nil {
+			continue
+		}
+		if net.ParseIP(e) != nil {
+			continue
+		}
+		return fmt.Errorf("%s: %q is not a valid IP address or CIDR", field, e)
+	}
+	return nil
+}
+
+// validateResources ensures a policy's resources is a non-empty JSON object.
+// The previous raw-length check accepted {}, null, [], and scalars, none of
+// which are valid Cloudflare resource maps and all of which would fail only
+// later at token-generation time.
+func validateResources(raw json.RawMessage) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return fmt.Errorf("resources is required")
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &m); err != nil {
+		return fmt.Errorf("resources must be a JSON object")
+	}
+	if len(m) == 0 {
+		return fmt.Errorf("resources must not be empty")
+	}
+	return nil
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,95 @@
+package cloudflaresecrets
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func TestValidateAccountID(t *testing.T) {
+	valid := []string{
+		"0123456789abcdef0123456789abcdef",
+	}
+	invalid := []string{
+		"",                                  // empty
+		"0123456789ABCDEF0123456789abcdef",  // uppercase
+		"0123456789abcdef0123456789abcde",   // 31 chars
+		"0123456789abcdef0123456789abcdef0", // 33 chars
+		"x/../../user",                      // path traversal
+		"acct?foo=bar",                      // query injection
+	}
+	for _, v := range valid {
+		if err := validateAccountID(v); err != nil {
+			t.Errorf("validateAccountID(%q) = %v, want nil", v, err)
+		}
+	}
+	for _, v := range invalid {
+		if err := validateAccountID(v); err == nil {
+			t.Errorf("validateAccountID(%q) = nil, want error", v)
+		}
+	}
+}
+
+func TestValidateIPRestrictions(t *testing.T) {
+	if err := validateIPRestrictions("f", []string{"203.0.113.0/24", "2001:db8::/32", "203.0.113.7"}); err != nil {
+		t.Errorf("valid CIDRs/IPs rejected: %v", err)
+	}
+	for _, bad := range [][]string{
+		{"203.0.113.0/33"}, // impossible mask
+		{"not-an-ip"},
+		{""},              // empty element (trailing comma)
+		{"10.0.0.0/8", ""}, // one good, one empty -> must still reject
+	} {
+		if err := validateIPRestrictions("f", bad); err == nil {
+			t.Errorf("validateIPRestrictions(%v) = nil, want error", bad)
+		}
+	}
+}
+
+func TestValidateResources(t *testing.T) {
+	if err := validateResources(json.RawMessage(`{"com.cloudflare.api.account.zone.abc":"*"}`)); err != nil {
+		t.Errorf("valid resources rejected: %v", err)
+	}
+	for _, bad := range []string{`{}`, `null`, `[]`, `"str"`, `123`, ``} {
+		if err := validateResources(json.RawMessage(bad)); err == nil {
+			t.Errorf("validateResources(%q) = nil, want error", bad)
+		}
+	}
+}
+
+// TestPathRolesWriteRejectsBadInput exercises the validators through the actual
+// role-write handler, confirming bad input fails at write time (not later).
+func TestPathRolesWriteRejectsBadInput(t *testing.T) {
+	b, storage := newTestBackend(t)
+	ctx := context.Background()
+
+	goodPolicies := `[{"permission_groups":[{"name":"DNS Write"}],"resources":{"com.cloudflare.api.account.zone.abc":"*"}}]`
+
+	cases := []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{"bad account_id", map[string]interface{}{"token_type": "account", "account_id": "x/../../user", "policies": goodPolicies}},
+		{"bad cidr", map[string]interface{}{"policies": goodPolicies, "request_ip_in": "not-an-ip"}},
+		{"empty resources", map[string]interface{}{"policies": `[{"permission_groups":[{"name":"DNS Write"}],"resources":{}}]`}},
+		{"null resources", map[string]interface{}{"policies": `[{"permission_groups":[{"name":"DNS Write"}],"resources":null}]`}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := b.HandleRequest(ctx, &logical.Request{
+				Operation: logical.CreateOperation,
+				Path:      "role/r",
+				Storage:   storage,
+				Data:      tc.data,
+			})
+			if err != nil {
+				t.Fatalf("unexpected transport error: %v", err)
+			}
+			if resp == nil || !resp.IsError() {
+				t.Fatalf("expected an error response, got %v", resp)
+			}
+		})
+	}
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -39,7 +39,7 @@ func TestValidateIPRestrictions(t *testing.T) {
 	for _, bad := range [][]string{
 		{"203.0.113.0/33"}, // impossible mask
 		{"not-an-ip"},
-		{""},              // empty element (trailing comma)
+		{""},               // empty element (trailing comma)
 		{"10.0.0.0/8", ""}, // one good, one empty -> must still reject
 	} {
 		if err := validateIPRestrictions("f", bad); err == nil {


### PR DESCRIPTION
# Security & robustness hardening: idempotent revocation, input validation, root rotation, R2 credentials

Addresses **#24** (Security & Design Audit). This PR implements fixes for every 🔴 High and 🟡 Medium finding in that audit, plus most 🟢 Low items. Two Lows are intentionally deferred (see the checklist).

## Summary

First off, thanks for building this — a Cloudflare secrets engine is a genuinely wanted piece of the Vault ecosystem ([hashicorp/vault#18932](https://github.com/hashicorp/vault/issues/18932)), and the core design (seal-wrapped config, lease-once, `expires_on` backstop, `InternalData` snapshotting) is solid.

Before adopting this on a production Vault (dynamic DNS + R2 provisioning without long-lived secrets), I ran the security and design review filed as #24 and then implemented fixes for what it surfaced. This PR is the result: correctness fixes, input hardening, parent-token rotation, and opt-in R2 S3 credentials. Every change is small and additive; nothing reworks the architecture.

It's structured as one focused commit per concern, so it reads cleanly commit-by-commit. **Happy to split it into stacked per-area PRs** following the fix order you suggested in the issue if you'd rather review that way.

## What changed

| Area | Change |
|---|---|
| **Revocation** | Treat Cloudflare's 404 (token already gone) as success, so a lease can't wedge in Vault's retry queue forever — this is exactly the state the `expires_on` backstop produces. Also degrade gracefully when the backend is deconfigured or the parent credential is removed while leases are outstanding. |
| **Input validation** | `account_id` must be a 32-hex Cloudflare ID and is `url.PathEscape`d where interpolated into the API path (closes a request-path injection vector); `request_ip_*` entries validated as IP/CIDR at write; policy `resources` must be a non-empty JSON object (the old check accepted `{}`, `null`, `[]`, scalars). |
| **Permission groups** | Reject ambiguous name→ID resolution (Cloudflare's catalog can share a display name across groups) instead of silently picking the last match. |
| **Root rotation** | New `config/rotate-root` rolls a parent token's value in place via Cloudflare's verify + `PUT tokens/{id}/value`, so the bootstrap credential is Vault-owned. Roll preserves the token's permissions — the only viable mechanism, since Cloudflare forbids API-minted tokens from holding token-management permissions. |
| **R2** | Opt-in role field `r2_s3_credentials` adds a derived S3 keypair (`r2_access_key_id` = token ID, `r2_secret_access_key` = SHA-256 of the token value) and `r2_endpoint` to the creds response, so R2 data-plane access works without long-lived secrets. |
| **HTTP client** | Injectable base URL (test seam), bounded response reads (`io.LimitReader`), retry/backoff honoring `Retry-After` (POST not retried on ambiguous failures), typed errors, and no longer echoing raw response bodies (which can contain a minted token) into errors. |
| **Concurrency** | A backend `RWMutex` serializes config/role read-modify-write, closing a lost-update race (e.g. a rotated parent token clobbered back). |
| **Hardening** | Full token masking on config read (was last-4 + length); mint/revoke/rotate logging without secrets; reject a token minted with no ID; add a buffer to the Cloudflare `expires_on` so a renewed-to-max lease can't wrap an expired token; reject non-2xx responses claiming `success:true`; report `RunningVersion` to Vault. |

## Findings coverage (#24)

Every High and Medium is addressed; L1–L3/L5/L6 done; L4/L7 deliberately not.

**🔴 High**
- [x] **H1** — Idempotent revocation, treat 404 as success · `fix(revoke)`
- [x] **H2** — Trust model documented in README (role/* write == parent-token authority; scope down the parent; one mount per trust boundary; rotate) · `harden: trust-model docs`. *The optional operator-configured permission allow-list is left as a follow-up; the primary fix (document the ceiling) is done.*
- [x] **H3** — `account_id` validated as 32-hex and `url.PathEscape`d in path building · `fix(validation)`
- [x] **H4** — Ambiguous permission-group names rejected ("reference it by id") · `harden`
- [x] **H5** — `config/rotate-root` endpoint (rolls value in place, never returns it) · `feat(config)`
- [x] **H6** — Injectable HTTP client + `httptest`-backed mint/revoke tests · `refactor(client)`

**🟡 Medium**
- [x] **M1** — `io.LimitReader` bound on response bodies · `refactor(client)`
- [x] **M2** — Retry/backoff honoring `Retry-After`; POST not retried on ambiguous failure · `refactor(client)`
- [x] **M3** — Backend `RWMutex` around config/role read-modify-write · `feat(config)`
- [x] **M4/M5** — Graceful revoke when parent credential / config is gone · `harden: graceful revoke`
- [x] **M6** — `request_ip_*` CIDRs validated at role-write · `fix(validation)`
- [x] **M7** — `resources` must be a non-empty JSON object · `fix(validation)`
- [x] **M8** — Full length-independent token mask on config read · `harden`
- [x] **M9** — Raw response body no longer echoed into parse errors · `refactor(client)`
- [x] **M10** — Buffer between Cloudflare `expires_on` and Vault max lease end · `harden: expiry buffer`
- [x] **M11** — R2 `access_key_id` / `secret_access_key` / endpoint surfaced (opt-in) · `feat(creds)`
- [x] **M12** — Mint/revoke/rotate logging (no secret values) · `harden`

**🟢 Low / Info**
- [x] **L1** — Reject a token minted with an empty ID · `harden`
- [x] **L2** — Require a 2xx status even when `success:true` · `harden: status guard`
- [x] **L3** — Wire `Backend.RunningVersion` · `harden: version`
- [x] **L5** — Defensive handling/log for missing/corrupt `token_id` · `harden: graceful revoke`
- [x] **L6** — Remove duplicated `clientForTokenType`; unify client construction · `harden: cleanup`
- [ ] **L4** — Orphan reconcile sweep — *deferred; inherent to secrets engines, mitigated by keeping `max_ttl` modest + the `expires_on` backstop.*
- [ ] **L7** — `LocalStorage: ["config"]` — *intentionally not set: config should replicate to DR/perf secondaries so a promoted node can still revoke outstanding leases.*

## New user-facing surface

- **`vault write cloudflare/config/rotate-root token_type=account`** — rolls the parent token in place; never returns the value.
- **Role field `r2_s3_credentials=true`** — creds responses additionally return `r2_access_key_id`, `r2_secret_access_key`, `r2_endpoint` for R2's S3 API.

Both are documented in the README (Security model + R2 + rotation sections).

## Testing

- **Unit (offline, no credentials):** 48 tests pass; `go build ./...` and `go vet ./...` clean. The client refactor makes the Cloudflare API injectable, so the previously acceptance-only mint/revoke path now has `httptest`-backed coverage (retry, no-retry-on-POST, body bounding, error redaction, idempotent-404, status-code guard, input validation, rotate-root handler, name-collision resolution, masking, R2 derivation, graceful revoke).
- **Live Cloudflare (against a throwaway test account):**
  - Core lifecycle + idempotent revocation: **verified** (Cloudflare returns 404 for a gone token).
  - `config/rotate-root`: **verified** end-to-end — a top-level token can roll its own value (`verify` → `roll` → new value verifies).
  - R2: the plugin mints a token with the object-write group and the **derived keypair performs real S3 PUT/GET/LIST/DELETE against a live R2 bucket**, then revocation deletes the token.
- Gated acceptance tests (`VAULT_ACC=1`, plus `CLOUDFLARE_TEST_R2=1` / `CLOUDFLARE_ROTATE_ROOT_DESTRUCTIVE=1`) cover the live paths; they skip by default.

## Notes for review

- **Test-only seam:** the backend has an unexported `apiBaseURL` used only to point clients at an `httptest` server in tests. It is **not** settable through any configured path, so it is not an operator/attacker surface — just flagging it so it isn't mistaken for one.
- **Existing tests updated:** a few config/mask tests used placeholder values (`"a"`, `"acct"`, last-4 masking) that the new validation/masking correctly rejects; they now use a valid hex ID and the new mask contract.
- **Deliberately deferred:** L4 (orphan reconcile sweep) and L7 (`LocalStorage`), with the rationale in the checklist above.
- **Not included (fork-specific):** a change that retargets the GoReleaser `release:` block to my fork is intentionally kept out of this PR — it's only relevant to my own release pipeline, not upstream.
- **Backwards compatible:** no storage format changes; new fields are additive and default off.
